### PR TITLE
Add connection proxy wrapper for IMAP retry functionality

### DIFF
--- a/src/imap_common.py
+++ b/src/imap_common.py
@@ -18,6 +18,7 @@ from email.header import decode_header
 from email.parser import BytesParser
 
 import imap_oauth2
+import imap_retry
 import restore_cache
 
 # Standard IMAP flags
@@ -287,7 +288,7 @@ def get_imap_connection(host, user, password=None, oauth2_token=None):
             conn.authenticate("XOAUTH2", lambda _: auth_string.encode())
         else:
             conn.login(user, password)
-        return conn
+        return imap_retry.ConnectionProxy(conn, log_fn=safe_print)
     except Exception as e:
         print(f"Connection error to {host}: {e}")
         return None

--- a/src/imap_common.py
+++ b/src/imap_common.py
@@ -214,7 +214,9 @@ def append_email(
             else:
                 normalized_flags = f"({stripped})"
 
-    resp, _ = imap_conn.append(f'"{folder_name}"', normalized_flags, date_str, raw_content)
+    resp, data = imap_conn.append(f'"{folder_name}"', normalized_flags, date_str, raw_content)
+    if resp != "OK":
+        safe_print(f"APPEND failed for {folder_name}: {resp} {data}")
     return resp == "OK"
 
 
@@ -651,10 +653,12 @@ def sync_flags_on_existing(imap_conn, folder_name, message_id, flags, size):
 
         if flags_to_add:
             flags_str = " ".join(flags_to_add)
-            typ, _ = imap_conn.store(msg_num, "+FLAGS", f"({flags_str})")
+            typ, data = imap_conn.store(msg_num, "+FLAGS", f"({flags_str})")
             if typ == "OK":
                 for flag in flags_to_add:
                     safe_print(f"  -> Synced flag: {flag}")
+            else:
+                safe_print(f"STORE +FLAGS failed for {message_id} in {folder_name}: {typ} {data}")
 
     except Exception as e:
         safe_print(f"Error syncing flags for {message_id} in {folder_name}: {e}")

--- a/src/imap_retry.py
+++ b/src/imap_retry.py
@@ -1,0 +1,80 @@
+"""
+IMAP Retry Logic
+
+Transparent retry wrapper for IMAP connections that handles transient
+server errors (e.g. Microsoft 365 "Server Busy") with exponential backoff.
+"""
+
+from __future__ import annotations
+
+import time
+
+TRANSIENT_PATTERNS = [b"UNAVAILABLE", b"Server Busy", b"try again", b"THROTTLED"]
+
+# Methods that are safe to retry and return (typ, data)
+_RETRYABLE_METHODS = frozenset(
+    {
+        "uid",
+        "select",
+        "search",
+        "fetch",
+        "append",
+        "store",
+        "list",
+        "create",
+        "expunge",
+        "noop",
+    }
+)
+
+
+def _is_transient_error(data):
+    """Check if IMAP response data contains transient error patterns."""
+    for item in data:
+        if isinstance(item, bytes):
+            for pattern in TRANSIENT_PATTERNS:
+                if pattern in item:
+                    return True
+    return False
+
+
+class ConnectionProxy:
+    """Transparent proxy that retries IMAP commands on transient server errors.
+
+    Wraps an imaplib.IMAP4 or IMAP4_SSL connection. For methods in
+    _RETRYABLE_METHODS that return (typ, data) tuples, retries on transient
+    errors with exponential backoff.
+    """
+
+    def __init__(self, conn, max_retries=3, initial_wait=5, log_fn=print):
+        if max_retries < 1:
+            raise ValueError(f"max_retries must be >= 1, got {max_retries}")
+        if initial_wait < 0:
+            raise ValueError(f"initial_wait must be >= 0, got {initial_wait}")
+        self._conn = conn
+        self._max_retries = max_retries
+        self._initial_wait = initial_wait
+        self._log_fn = log_fn
+
+    def __getattr__(self, name):
+        attr = getattr(self._conn, name)
+        if name not in _RETRYABLE_METHODS or not callable(attr):
+            return attr
+
+        def wrapper(*args, **kwargs):
+            last_result = None
+            for attempt in range(self._max_retries):
+                result = attr(*args, **kwargs)
+                if not isinstance(result, tuple) or len(result) < 2:
+                    return result
+                typ, data = result[0], result[1]
+                if typ == "OK" or not _is_transient_error(data):
+                    return result
+                last_result = result
+                if attempt + 1 < self._max_retries:
+                    wait = self._initial_wait * (2**attempt)  # 5s, 10s, 20s
+                    self._log_fn(f"Server busy, retrying in {wait}s... (attempt {attempt + 1}/{self._max_retries})")
+                    time.sleep(wait)
+            return last_result
+
+        return wrapper

--- a/src/imap_retry.py
+++ b/src/imap_retry.py
@@ -9,42 +9,32 @@ from __future__ import annotations
 
 import time
 
-TRANSIENT_PATTERNS = [b"UNAVAILABLE", b"Server Busy", b"try again", b"THROTTLED"]
-
-# Methods that are safe to retry and return (typ, data)
-_RETRYABLE_METHODS = frozenset(
-    {
-        "uid",
-        "select",
-        "search",
-        "fetch",
-        "append",
-        "store",
-        "list",
-        "create",
-        "expunge",
-        "noop",
-    }
-)
-
-
-def _is_transient_error(data):
-    """Check if IMAP response data contains transient error patterns."""
-    for item in data:
-        if isinstance(item, bytes):
-            for pattern in TRANSIENT_PATTERNS:
-                if pattern in item:
-                    return True
-    return False
-
 
 class ConnectionProxy:
     """Transparent proxy that retries IMAP commands on transient server errors.
 
     Wraps an imaplib.IMAP4 or IMAP4_SSL connection. For methods in
-    _RETRYABLE_METHODS that return (typ, data) tuples, retries on transient
+    RETRYABLE_METHODS that return (typ, data) tuples, retries on transient
     errors with exponential backoff.
     """
+
+    TRANSIENT_PATTERNS = [b"UNAVAILABLE", b"Server Busy", b"try again", b"THROTTLED"]
+
+    # Methods that are safe to retry and return (typ, data)
+    RETRYABLE_METHODS = frozenset(
+        {
+            "uid",
+            "select",
+            "search",
+            "fetch",
+            "append",
+            "store",
+            "list",
+            "create",
+            "expunge",
+            "noop",
+        }
+    )
 
     def __init__(self, conn, max_retries=3, initial_wait=5, log_fn=print):
         if max_retries < 1:
@@ -56,9 +46,19 @@ class ConnectionProxy:
         self._initial_wait = initial_wait
         self._log_fn = log_fn
 
+    @classmethod
+    def _is_transient_error(cls, data):
+        """Check if IMAP response data contains transient error patterns."""
+        for item in data:
+            if isinstance(item, bytes):
+                for pattern in cls.TRANSIENT_PATTERNS:
+                    if pattern in item:
+                        return True
+        return False
+
     def __getattr__(self, name):
         attr = getattr(self._conn, name)
-        if name not in _RETRYABLE_METHODS or not callable(attr):
+        if name not in self.RETRYABLE_METHODS or not callable(attr):
             return attr
 
         def wrapper(*args, **kwargs):
@@ -68,7 +68,7 @@ class ConnectionProxy:
                 if not isinstance(result, tuple) or len(result) < 2:
                     return result
                 typ, data = result[0], result[1]
-                if typ == "OK" or not _is_transient_error(data):
+                if typ == "OK" or not self._is_transient_error(data):
                     return result
                 last_result = result
                 if attempt + 1 < self._max_retries:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -44,7 +44,7 @@ def create_server_pair(src_data=None, dest_data=None):
     # It dropped returning 't'. I need to fix that or update consumers to not need 't'.
     # Shutdown() stops serve_forever loop. join() is nice but maybe not strictly required if we trust shutdown.
     # However, to avoid ResourceWarnings, we might want 't'.
-    
+
     return (None, src_s, p1_actual), (None, dest_s, p2_actual)
 
 
@@ -53,11 +53,13 @@ def shutdown_server_pair(src_tuple, dest_tuple):
     src_t, src_s, _ = src_tuple
     dest_t, dest_s, _ = dest_tuple
     src_s.shutdown()
-    src_s.server_close() # Explicitly close socket
+    src_s.server_close()  # Explicitly close socket
     dest_s.shutdown()
     dest_s.server_close()
-    if src_t: src_t.join(timeout=2)
-    if dest_t: dest_t.join(timeout=2)
+    if src_t:
+        src_t.join(timeout=2)
+    if dest_t:
+        dest_t.join(timeout=2)
 
 
 @pytest.fixture

--- a/test/test_count_imap_emails.py
+++ b/test/test_count_imap_emails.py
@@ -196,7 +196,6 @@ class TestImapCommonHelpers:
         with patch.object(imap_common.imaplib, "IMAP4_SSL", FakeIMAP):
             conn = imap_common.get_imap_connection("host", "user", oauth2_token="token")
 
-        assert isinstance(conn, FakeIMAP)
         assert conn.auth_called is True
         assert conn.login_called is False
 
@@ -217,7 +216,6 @@ class TestImapCommonHelpers:
         with patch.object(imap_common.imaplib, "IMAP4_SSL", FakeIMAP):
             conn = imap_common.get_imap_connection("host", "user", password="pass")
 
-        assert isinstance(conn, FakeIMAP)
         assert conn.login_called is True
         assert conn.auth_called is False
 

--- a/test/test_imap_retry.py
+++ b/test/test_imap_retry.py
@@ -1,0 +1,177 @@
+"""
+Tests for imap_retry.py
+
+Tests cover:
+- Transient error detection
+- ConnectionProxy transparent proxying
+- Retry with exponential backoff on transient errors
+- Pass-through for non-retryable methods
+- Pass-through for non-transient errors
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+
+import imap_retry
+
+
+class TestIsTransientError:
+    def test_unavailable(self):
+        assert imap_retry._is_transient_error([b"NO [UNAVAILABLE] Server Busy"]) is True
+
+    def test_server_busy(self):
+        assert imap_retry._is_transient_error([b"NO Server Busy"]) is True
+
+    def test_try_again(self):
+        assert imap_retry._is_transient_error([b"NO try again later"]) is True
+
+    def test_throttled(self):
+        assert imap_retry._is_transient_error([b"NO [THROTTLED]"]) is True
+
+    def test_not_transient(self):
+        assert imap_retry._is_transient_error([b"NO [AUTHENTICATIONFAILED]"]) is False
+
+    def test_empty_data(self):
+        assert imap_retry._is_transient_error([]) is False
+
+    def test_non_bytes_ignored(self):
+        assert imap_retry._is_transient_error(["UNAVAILABLE"]) is False
+
+    def test_multiple_items_matches_second(self):
+        assert imap_retry._is_transient_error([b"OK", b"NO [UNAVAILABLE]"]) is True
+
+
+class TestConnectionProxy:
+    def test_ok_response_returns_immediately(self):
+        conn = MagicMock()
+        conn.select.return_value = ("OK", [b"1234"])
+        wrapper = imap_retry.ConnectionProxy(conn)
+
+        result = wrapper.select('"INBOX"')
+
+        assert result == ("OK", [b"1234"])
+        assert conn.select.call_count == 1
+
+    def test_non_transient_error_not_retried(self):
+        conn = MagicMock()
+        conn.select.return_value = ("NO", [b"AUTHENTICATIONFAILED"])
+        wrapper = imap_retry.ConnectionProxy(conn)
+
+        result = wrapper.select('"INBOX"')
+
+        assert result == ("NO", [b"AUTHENTICATIONFAILED"])
+        assert conn.select.call_count == 1
+
+    @patch("imap_retry.time.sleep")
+    def test_transient_error_retried_then_succeeds(self, mock_sleep):
+        conn = MagicMock()
+        conn.select.side_effect = [
+            ("NO", [b"[UNAVAILABLE] Server Busy"]),
+            ("OK", [b"1234"]),
+        ]
+        wrapper = imap_retry.ConnectionProxy(conn, max_retries=3, initial_wait=5)
+
+        result = wrapper.select('"INBOX"')
+
+        assert result == ("OK", [b"1234"])
+        assert conn.select.call_count == 2
+        mock_sleep.assert_called_once_with(5)
+
+    @patch("imap_retry.time.sleep")
+    def test_exponential_backoff(self, mock_sleep):
+        conn = MagicMock()
+        conn.fetch.side_effect = [
+            ("NO", [b"[UNAVAILABLE] Server Busy"]),
+            ("NO", [b"[UNAVAILABLE] Server Busy"]),
+            ("OK", [b"data"]),
+        ]
+        wrapper = imap_retry.ConnectionProxy(conn, max_retries=3, initial_wait=5)
+
+        result = wrapper.fetch("1", "(RFC822)")
+
+        assert result == ("OK", [b"data"])
+        assert conn.fetch.call_count == 3
+        assert mock_sleep.call_args_list[0][0] == (5,)
+        assert mock_sleep.call_args_list[1][0] == (10,)
+
+    @patch("imap_retry.time.sleep")
+    def test_max_retries_exhausted_returns_last_error(self, mock_sleep):
+        conn = MagicMock()
+        conn.store.return_value = ("NO", [b"[UNAVAILABLE] Server Busy"])
+        wrapper = imap_retry.ConnectionProxy(conn, max_retries=3, initial_wait=5)
+
+        result = wrapper.store("1", "+FLAGS", "(\\Seen)")
+
+        assert result == ("NO", [b"[UNAVAILABLE] Server Busy"])
+        assert conn.store.call_count == 3
+        assert mock_sleep.call_count == 2  # sleeps between attempts, not after last
+
+    def test_non_retryable_method_passes_through(self):
+        conn = MagicMock()
+        conn.login.return_value = ("NO", [b"[UNAVAILABLE] Server Busy"])
+        wrapper = imap_retry.ConnectionProxy(conn)
+
+        result = wrapper.login("user", "pass")
+
+        assert result == ("NO", [b"[UNAVAILABLE] Server Busy"])
+        assert conn.login.call_count == 1
+
+    def test_non_callable_attribute_passes_through(self):
+        conn = MagicMock()
+        conn.state = "AUTH"
+        wrapper = imap_retry.ConnectionProxy(conn)
+
+        assert wrapper.state == "AUTH"
+
+    def test_non_tuple_return_passes_through(self):
+        conn = MagicMock()
+        conn.noop.return_value = "unexpected"
+        wrapper = imap_retry.ConnectionProxy(conn)
+
+        result = wrapper.noop()
+
+        assert result == "unexpected"
+        assert conn.noop.call_count == 1
+
+    def test_uid_method_retried(self):
+        conn = MagicMock()
+        conn.uid.side_effect = [
+            ("NO", [b"[THROTTLED]"]),
+            ("OK", [b"1 2 3"]),
+        ]
+        wrapper = imap_retry.ConnectionProxy(conn, max_retries=3, initial_wait=0)
+
+        result = wrapper.uid("search", None, "ALL")
+
+        assert result == ("OK", [b"1 2 3"])
+        assert conn.uid.call_count == 2
+
+    def test_append_method_retried(self):
+        conn = MagicMock()
+        conn.append.side_effect = [
+            ("NO", [b"try again later"]),
+            ("OK", [b"APPENDUID"]),
+        ]
+        wrapper = imap_retry.ConnectionProxy(conn, max_retries=3, initial_wait=0)
+
+        result = wrapper.append('"INBOX"', None, None, b"message data")
+
+        assert result == ("OK", [b"APPENDUID"])
+        assert conn.append.call_count == 2
+
+    def test_max_retries_zero_raises(self):
+        with pytest.raises(ValueError, match="max_retries must be >= 1"):
+            imap_retry.ConnectionProxy(MagicMock(), max_retries=0)
+
+    def test_max_retries_negative_raises(self):
+        with pytest.raises(ValueError, match="max_retries must be >= 1"):
+            imap_retry.ConnectionProxy(MagicMock(), max_retries=-1)
+
+    def test_initial_wait_negative_raises(self):
+        with pytest.raises(ValueError, match="initial_wait must be >= 0"):
+            imap_retry.ConnectionProxy(MagicMock(), initial_wait=-1)

--- a/test/test_imap_retry.py
+++ b/test/test_imap_retry.py
@@ -9,13 +9,9 @@ Tests cover:
 - Pass-through for non-transient errors
 """
 
+import imaplib
 import os
 import sys
-import os
-import threading
-import imaplib
-import time
-from typing import Tuple
 
 import pytest
 
@@ -24,71 +20,6 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../t
 
 import imap_retry
 from mock_imap_server import start_server_thread as start_mock_server
-
-
-class TestIsTransientError:
-    @pytest.fixture(scope="class")
-    def imap_server_info(self):
-        """Starts a background IMAP server for the test class."""
-        folders = {"INBOX": []}
-        server, port = start_mock_server(folders)
-        yield server, port
-        server.shutdown()
-        server.server_close()
-
-    @pytest.fixture
-    def imap_conn(self, imap_server_info):
-        """Returns a connected IMAP4 client instance."""
-        server, port = imap_server_info
-        client = imaplib.IMAP4("127.0.0.1", port)
-        client.login("user", "pass")
-        yield client
-        try:
-            client.logout()
-        except:
-            pass
-
-    def _get_error_data_from_conn(self, client, command_arg: str):
-        try:
-            typ, data = client.select(f'"{command_arg}"')
-            if typ == "NO":
-                return data
-            return []
-        except imaplib.IMAP4.error as e:
-            msg = str(e)
-            return [msg.encode("utf-8")]
-
-    def test_unavailable(self, imap_conn):
-        data = self._get_error_data_from_conn(imap_conn, "NO [UNAVAILABLE] Server Busy")
-        assert imap_retry._is_transient_error(data) is True
-
-    def test_server_busy(self, imap_conn):
-        data = self._get_error_data_from_conn(imap_conn, "NO Server Busy")
-        assert imap_retry._is_transient_error(data) is True
-
-    def test_try_again(self, imap_conn):
-        data = self._get_error_data_from_conn(imap_conn, "NO try again later")
-        assert imap_retry._is_transient_error(data) is True
-
-    def test_throttled(self, imap_conn):
-        data = self._get_error_data_from_conn(imap_conn, "NO [THROTTLED]")
-        assert imap_retry._is_transient_error(data) is True
-
-    def test_not_transient(self, imap_conn):
-        data = self._get_error_data_from_conn(imap_conn, "NO [AUTHENTICATIONFAILED]")
-        assert imap_retry._is_transient_error(data) is False
-
-    def test_empty_data(self, imap_conn):
-        data = self._get_error_data_from_conn(imap_conn, "EMPTY")
-        assert imap_retry._is_transient_error(data) is False
-
-    def test_non_bytes_ignored(self, imap_conn):
-        data = ["UNAVAILABLE", b"NO [AUTHENTICATIONFAILED]"] 
-        assert imap_retry._is_transient_error(data) is False
-
-    def test_multiple_items_matches_second(self, imap_conn):
-        data = [b"OK", b"NO [UNAVAILABLE]"]
-        assert imap_retry._is_transient_error(data) is True
 
 
 class TestConnectionProxy:
@@ -112,76 +43,137 @@ class TestConnectionProxy:
             pass
 
     @pytest.fixture
-    def proxy(self, imap_conn):
-        # Short wait to speed up tests
-        return imap_retry.ConnectionProxy(imap_conn, max_retries=3, initial_wait=0.01)
+    def captured_logs(self):
+        logs = []
 
-    def test_ok_response_returns_immediately(self, proxy):
+        def log_fn(msg):
+            logs.append(msg)
+
+        return logs, log_fn
+
+    @pytest.fixture
+    def proxy(self, imap_conn, captured_logs):
+        # Short wait to speed up tests
+        logs, log_fn = captured_logs
+        return imap_retry.ConnectionProxy(imap_conn, max_retries=3, initial_wait=0.01, log_fn=log_fn)
+
+    def test_transient_retry_logic_unavailable(self, proxy, captured_logs):
+        """Test detection of 'NO [UNAVAILABLE]' error pattern."""
+        try:
+            logs, _ = captured_logs
+            # Server will echo "NO [UNAVAILABLE] Server Busy" and fail continuously
+            typ, data = proxy.select('"NO [UNAVAILABLE] Server Busy"')
+            assert typ == "NO"
+            # Should have retried max_retries-1 times before returning last error
+            assert len(logs) == 2  # Retries on attempt 1 and 2, then fail on 3
+            assert "attempt 1/3" in logs[0]
+            assert "attempt 2/3" in logs[1]
+        except Exception:
+            raise
+
+    def test_transient_retry_logic_server_busy(self, proxy, captured_logs):
+        """Test detection of 'NO Server Busy' error pattern."""
+        logs, _ = captured_logs
+        typ, data = proxy.select('"NO Server Busy"')
+        assert typ == "NO"
+        assert len(logs) == 2
+
+    def test_transient_retry_logic_try_again(self, proxy, captured_logs):
+        """Test detection of 'try again' error pattern."""
+        logs, _ = captured_logs
+        typ, data = proxy.select('"NO try again later"')
+        assert typ == "NO"
+        assert len(logs) == 2
+
+    def test_transient_retry_logic_throttled(self, proxy, captured_logs):
+        """Test detection of 'THROTTLED' error pattern."""
+        logs, _ = captured_logs
+        typ, data = proxy.select('"NO [THROTTLED]"')
+        assert typ == "NO"
+        assert len(logs) == 2
+
+    def test_non_transient_no_retry_empty(self, proxy, captured_logs):
+        """Test mismatch on empty/irrelevant data."""
+        logs, _ = captured_logs
+        # EMPTY arg causes mock to return OK with 0 items but generally here we want an error condition
+        # Mock server "EMPTY" folder returns OK.
+        # We need an error that is NOT transient.
+        # "NO [UNKNOWN]"
+        typ, data = proxy.select('"NO [UNKNOWN]"')
+        assert typ == "NO"
+        assert len(logs) == 0
+
+    def test_ok_response_returns_immediately(self, proxy, captured_logs):
+        logs, _ = captured_logs
         typ, data = proxy.select('"INBOX"')
         assert typ == "OK"
+        assert len(logs) == 0
 
-    def test_non_transient_error_not_retried(self, proxy):
+    def test_non_transient_error_not_retried(self, proxy, captured_logs):
+        logs, _ = captured_logs
         typ, data = proxy.select('"NO [AUTHENTICATIONFAILED]"')
         assert typ == "NO"
         assert b"AUTHENTICATIONFAILED" in data[0]
+        assert len(logs) == 0
 
-    def test_transient_error_retried_then_succeeds(self, proxy):
+    def test_transient_error_retried_then_succeeds(self, proxy, captured_logs):
+        logs, _ = captured_logs
         # Retry 2 times (fail count 2, so 3rd succeeds)
-        # We use a unique mailbox name to separate test cases or rely on new connection
         # RETRY_2 triggers 2 failures then OK.
         typ, data = proxy.select('"RETRY_2"')
         assert typ == "OK"
+        assert len(logs) == 2
+        assert "attempt 1/3" in logs[0]
+        assert "attempt 2/3" in logs[1]
 
-    def test_exponential_backoff_logic(self, proxy):
-        # Must be selected to fetch
+    def test_exponential_backoff_logic(self, proxy, captured_logs):
+        logs, _ = captured_logs
         proxy.select('"INBOX"')
-        # RETRY_2 covers that it engages the retry loop twice then succeeds
-        typ, data = proxy.fetch('1', '(BODY RETRY_2)')
+        typ, data = proxy.fetch("1", "(BODY RETRY_2)")
         assert typ == "OK"
+        assert len(logs) == 2
+        # Verify message content for backoff?
+        # approximate wait time is hard to verify without mocking sleep, but we verify calls were made.
 
-    def test_max_retries_exhausted_returns_last_error(self, proxy):
-        # Must be selected to store
+    def test_max_retries_exhausted_returns_last_error(self, proxy, captured_logs):
+        logs, _ = captured_logs
         proxy.select('"INBOX"')
         # Fail 5 times. Max retries is 3. Result should be error.
-        typ, data = proxy.store('1', '+FLAGS', '(\\Seen RETRY_5)')
+        typ, data = proxy.store("1", "+FLAGS", "(\\Seen RETRY_5)")
         assert typ == "NO"
         assert b"UNAVAILABLE" in data[0]
+        assert len(logs) == 2
 
-    def test_non_retryable_method_passes_through(self, proxy):
-        # Instead of login (which fails in AUTH state), use capability
-        # capability is NOT in _RETRYABLE_METHODS
+    def test_non_retryable_method_passes_through(self, proxy, captured_logs):
+        logs, _ = captured_logs
         res = proxy.capability()
         assert res[0] == "OK"
+        assert len(logs) == 0
 
     def test_non_callable_attribute_passes_through(self, proxy):
-        # IMAP4 has 'state' attribute
         assert proxy.state == "AUTH"
 
     def test_non_tuple_return_passes_through(self):
-        # Create a dummy class that returns non-tuple
         class DummyConn:
             def noop(self):
                 return "unexpected"
-        
+
         d = DummyConn()
         p = imap_retry.ConnectionProxy(d)
         assert p.noop() == "unexpected"
 
-    def test_uid_method_retried(self, proxy):
-        # Must be selected (most UID commands)
+    def test_uid_method_retried(self, proxy, captured_logs):
+        logs, _ = captured_logs
         proxy.select('"INBOX"')
-        # UID SEARCH RETRY_1
-        # Mock server needs to parse RETRY_1 from args.
-        typ, data = proxy.uid('SEARCH', 'RETRY_1')
+        typ, data = proxy.uid("SEARCH", "RETRY_1")
         assert typ == "OK"
+        assert len(logs) == 1
 
-    def test_append_method_retried(self, proxy):
-        # APPEND "INBOX" {7}
-        # retry logic based on mailbox name or args?
-        # args passed to proxy.append: mailbox, flags, date_time, message
-        # We pass mailbox="RETRY_1"
+    def test_append_method_retried(self, proxy, captured_logs):
+        logs, _ = captured_logs
         typ, data = proxy.append('"RETRY_1"', None, None, b"data")
         assert typ == "OK"
+        assert len(logs) == 1
 
     def test_max_retries_zero_raises(self):
         with pytest.raises(ValueError, match="max_retries must be >= 1"):

--- a/test/test_imap_retry.py
+++ b/test/test_imap_retry.py
@@ -11,167 +11,186 @@ Tests cover:
 
 import os
 import sys
-from unittest.mock import MagicMock, patch
+import os
+import threading
+import imaplib
+import time
+from typing import Tuple
 
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../tools")))
 
 import imap_retry
+from mock_imap_server import start_server_thread as start_mock_server
 
 
 class TestIsTransientError:
-    def test_unavailable(self):
-        assert imap_retry._is_transient_error([b"NO [UNAVAILABLE] Server Busy"]) is True
+    @pytest.fixture(scope="class")
+    def imap_server_info(self):
+        """Starts a background IMAP server for the test class."""
+        folders = {"INBOX": []}
+        server, port = start_mock_server(folders)
+        yield server, port
+        server.shutdown()
+        server.server_close()
 
-    def test_server_busy(self):
-        assert imap_retry._is_transient_error([b"NO Server Busy"]) is True
+    @pytest.fixture
+    def imap_conn(self, imap_server_info):
+        """Returns a connected IMAP4 client instance."""
+        server, port = imap_server_info
+        client = imaplib.IMAP4("127.0.0.1", port)
+        client.login("user", "pass")
+        yield client
+        try:
+            client.logout()
+        except:
+            pass
 
-    def test_try_again(self):
-        assert imap_retry._is_transient_error([b"NO try again later"]) is True
+    def _get_error_data_from_conn(self, client, command_arg: str):
+        try:
+            typ, data = client.select(f'"{command_arg}"')
+            if typ == "NO":
+                return data
+            return []
+        except imaplib.IMAP4.error as e:
+            msg = str(e)
+            return [msg.encode("utf-8")]
 
-    def test_throttled(self):
-        assert imap_retry._is_transient_error([b"NO [THROTTLED]"]) is True
+    def test_unavailable(self, imap_conn):
+        data = self._get_error_data_from_conn(imap_conn, "NO [UNAVAILABLE] Server Busy")
+        assert imap_retry._is_transient_error(data) is True
 
-    def test_not_transient(self):
-        assert imap_retry._is_transient_error([b"NO [AUTHENTICATIONFAILED]"]) is False
+    def test_server_busy(self, imap_conn):
+        data = self._get_error_data_from_conn(imap_conn, "NO Server Busy")
+        assert imap_retry._is_transient_error(data) is True
 
-    def test_empty_data(self):
-        assert imap_retry._is_transient_error([]) is False
+    def test_try_again(self, imap_conn):
+        data = self._get_error_data_from_conn(imap_conn, "NO try again later")
+        assert imap_retry._is_transient_error(data) is True
 
-    def test_non_bytes_ignored(self):
-        assert imap_retry._is_transient_error(["UNAVAILABLE"]) is False
+    def test_throttled(self, imap_conn):
+        data = self._get_error_data_from_conn(imap_conn, "NO [THROTTLED]")
+        assert imap_retry._is_transient_error(data) is True
 
-    def test_multiple_items_matches_second(self):
-        assert imap_retry._is_transient_error([b"OK", b"NO [UNAVAILABLE]"]) is True
+    def test_not_transient(self, imap_conn):
+        data = self._get_error_data_from_conn(imap_conn, "NO [AUTHENTICATIONFAILED]")
+        assert imap_retry._is_transient_error(data) is False
+
+    def test_empty_data(self, imap_conn):
+        data = self._get_error_data_from_conn(imap_conn, "EMPTY")
+        assert imap_retry._is_transient_error(data) is False
+
+    def test_non_bytes_ignored(self, imap_conn):
+        data = ["UNAVAILABLE", b"NO [AUTHENTICATIONFAILED]"] 
+        assert imap_retry._is_transient_error(data) is False
+
+    def test_multiple_items_matches_second(self, imap_conn):
+        data = [b"OK", b"NO [UNAVAILABLE]"]
+        assert imap_retry._is_transient_error(data) is True
 
 
 class TestConnectionProxy:
-    def test_ok_response_returns_immediately(self):
-        conn = MagicMock()
-        conn.select.return_value = ("OK", [b"1234"])
-        wrapper = imap_retry.ConnectionProxy(conn)
+    @pytest.fixture(scope="class")
+    def imap_server_info(self):
+        folders = {"INBOX": []}
+        server, port = start_mock_server(folders)
+        yield server, port
+        server.shutdown()
+        server.server_close()
 
-        result = wrapper.select('"INBOX"')
+    @pytest.fixture
+    def imap_conn(self, imap_server_info):
+        server, port = imap_server_info
+        client = imaplib.IMAP4("127.0.0.1", port)
+        client.login("user", "pass")
+        yield client
+        try:
+            client.logout()
+        except:
+            pass
 
-        assert result == ("OK", [b"1234"])
-        assert conn.select.call_count == 1
+    @pytest.fixture
+    def proxy(self, imap_conn):
+        # Short wait to speed up tests
+        return imap_retry.ConnectionProxy(imap_conn, max_retries=3, initial_wait=0.01)
 
-    def test_non_transient_error_not_retried(self):
-        conn = MagicMock()
-        conn.select.return_value = ("NO", [b"AUTHENTICATIONFAILED"])
-        wrapper = imap_retry.ConnectionProxy(conn)
+    def test_ok_response_returns_immediately(self, proxy):
+        typ, data = proxy.select('"INBOX"')
+        assert typ == "OK"
 
-        result = wrapper.select('"INBOX"')
+    def test_non_transient_error_not_retried(self, proxy):
+        typ, data = proxy.select('"NO [AUTHENTICATIONFAILED]"')
+        assert typ == "NO"
+        assert b"AUTHENTICATIONFAILED" in data[0]
 
-        assert result == ("NO", [b"AUTHENTICATIONFAILED"])
-        assert conn.select.call_count == 1
+    def test_transient_error_retried_then_succeeds(self, proxy):
+        # Retry 2 times (fail count 2, so 3rd succeeds)
+        # We use a unique mailbox name to separate test cases or rely on new connection
+        # RETRY_2 triggers 2 failures then OK.
+        typ, data = proxy.select('"RETRY_2"')
+        assert typ == "OK"
 
-    @patch("imap_retry.time.sleep")
-    def test_transient_error_retried_then_succeeds(self, mock_sleep):
-        conn = MagicMock()
-        conn.select.side_effect = [
-            ("NO", [b"[UNAVAILABLE] Server Busy"]),
-            ("OK", [b"1234"]),
-        ]
-        wrapper = imap_retry.ConnectionProxy(conn, max_retries=3, initial_wait=5)
+    def test_exponential_backoff_logic(self, proxy):
+        # Must be selected to fetch
+        proxy.select('"INBOX"')
+        # RETRY_2 covers that it engages the retry loop twice then succeeds
+        typ, data = proxy.fetch('1', '(BODY RETRY_2)')
+        assert typ == "OK"
 
-        result = wrapper.select('"INBOX"')
+    def test_max_retries_exhausted_returns_last_error(self, proxy):
+        # Must be selected to store
+        proxy.select('"INBOX"')
+        # Fail 5 times. Max retries is 3. Result should be error.
+        typ, data = proxy.store('1', '+FLAGS', '(\\Seen RETRY_5)')
+        assert typ == "NO"
+        assert b"UNAVAILABLE" in data[0]
 
-        assert result == ("OK", [b"1234"])
-        assert conn.select.call_count == 2
-        mock_sleep.assert_called_once_with(5)
+    def test_non_retryable_method_passes_through(self, proxy):
+        # Instead of login (which fails in AUTH state), use capability
+        # capability is NOT in _RETRYABLE_METHODS
+        res = proxy.capability()
+        assert res[0] == "OK"
 
-    @patch("imap_retry.time.sleep")
-    def test_exponential_backoff(self, mock_sleep):
-        conn = MagicMock()
-        conn.fetch.side_effect = [
-            ("NO", [b"[UNAVAILABLE] Server Busy"]),
-            ("NO", [b"[UNAVAILABLE] Server Busy"]),
-            ("OK", [b"data"]),
-        ]
-        wrapper = imap_retry.ConnectionProxy(conn, max_retries=3, initial_wait=5)
-
-        result = wrapper.fetch("1", "(RFC822)")
-
-        assert result == ("OK", [b"data"])
-        assert conn.fetch.call_count == 3
-        assert mock_sleep.call_args_list[0][0] == (5,)
-        assert mock_sleep.call_args_list[1][0] == (10,)
-
-    @patch("imap_retry.time.sleep")
-    def test_max_retries_exhausted_returns_last_error(self, mock_sleep):
-        conn = MagicMock()
-        conn.store.return_value = ("NO", [b"[UNAVAILABLE] Server Busy"])
-        wrapper = imap_retry.ConnectionProxy(conn, max_retries=3, initial_wait=5)
-
-        result = wrapper.store("1", "+FLAGS", "(\\Seen)")
-
-        assert result == ("NO", [b"[UNAVAILABLE] Server Busy"])
-        assert conn.store.call_count == 3
-        assert mock_sleep.call_count == 2  # sleeps between attempts, not after last
-
-    def test_non_retryable_method_passes_through(self):
-        conn = MagicMock()
-        conn.login.return_value = ("NO", [b"[UNAVAILABLE] Server Busy"])
-        wrapper = imap_retry.ConnectionProxy(conn)
-
-        result = wrapper.login("user", "pass")
-
-        assert result == ("NO", [b"[UNAVAILABLE] Server Busy"])
-        assert conn.login.call_count == 1
-
-    def test_non_callable_attribute_passes_through(self):
-        conn = MagicMock()
-        conn.state = "AUTH"
-        wrapper = imap_retry.ConnectionProxy(conn)
-
-        assert wrapper.state == "AUTH"
+    def test_non_callable_attribute_passes_through(self, proxy):
+        # IMAP4 has 'state' attribute
+        assert proxy.state == "AUTH"
 
     def test_non_tuple_return_passes_through(self):
-        conn = MagicMock()
-        conn.noop.return_value = "unexpected"
-        wrapper = imap_retry.ConnectionProxy(conn)
+        # Create a dummy class that returns non-tuple
+        class DummyConn:
+            def noop(self):
+                return "unexpected"
+        
+        d = DummyConn()
+        p = imap_retry.ConnectionProxy(d)
+        assert p.noop() == "unexpected"
 
-        result = wrapper.noop()
+    def test_uid_method_retried(self, proxy):
+        # Must be selected (most UID commands)
+        proxy.select('"INBOX"')
+        # UID SEARCH RETRY_1
+        # Mock server needs to parse RETRY_1 from args.
+        typ, data = proxy.uid('SEARCH', 'RETRY_1')
+        assert typ == "OK"
 
-        assert result == "unexpected"
-        assert conn.noop.call_count == 1
-
-    def test_uid_method_retried(self):
-        conn = MagicMock()
-        conn.uid.side_effect = [
-            ("NO", [b"[THROTTLED]"]),
-            ("OK", [b"1 2 3"]),
-        ]
-        wrapper = imap_retry.ConnectionProxy(conn, max_retries=3, initial_wait=0)
-
-        result = wrapper.uid("search", None, "ALL")
-
-        assert result == ("OK", [b"1 2 3"])
-        assert conn.uid.call_count == 2
-
-    def test_append_method_retried(self):
-        conn = MagicMock()
-        conn.append.side_effect = [
-            ("NO", [b"try again later"]),
-            ("OK", [b"APPENDUID"]),
-        ]
-        wrapper = imap_retry.ConnectionProxy(conn, max_retries=3, initial_wait=0)
-
-        result = wrapper.append('"INBOX"', None, None, b"message data")
-
-        assert result == ("OK", [b"APPENDUID"])
-        assert conn.append.call_count == 2
+    def test_append_method_retried(self, proxy):
+        # APPEND "INBOX" {7}
+        # retry logic based on mailbox name or args?
+        # args passed to proxy.append: mailbox, flags, date_time, message
+        # We pass mailbox="RETRY_1"
+        typ, data = proxy.append('"RETRY_1"', None, None, b"data")
+        assert typ == "OK"
 
     def test_max_retries_zero_raises(self):
         with pytest.raises(ValueError, match="max_retries must be >= 1"):
-            imap_retry.ConnectionProxy(MagicMock(), max_retries=0)
+            imap_retry.ConnectionProxy(None, max_retries=0)
 
     def test_max_retries_negative_raises(self):
         with pytest.raises(ValueError, match="max_retries must be >= 1"):
-            imap_retry.ConnectionProxy(MagicMock(), max_retries=-1)
+            imap_retry.ConnectionProxy(None, max_retries=-1)
 
     def test_initial_wait_negative_raises(self):
         with pytest.raises(ValueError, match="initial_wait must be >= 0"):
-            imap_retry.ConnectionProxy(MagicMock(), initial_wait=-1)
+            imap_retry.ConnectionProxy(None, initial_wait=-1)

--- a/tools/mock_imap_server.py
+++ b/tools/mock_imap_server.py
@@ -1,4 +1,3 @@
-import re
 import socketserver
 import threading
 
@@ -15,15 +14,15 @@ class MockIMAPHandler(socketserver.StreamRequestHandler):
     def handle(self):
         self.wfile.write(b"* OK [CAPABILITY IMAP4rev1] Mock IMAP Server Ready\r\n")
         self.selected_folder = None
-        
+
         # Check if server has folders, if not, initialize
         if hasattr(self.server, "folders"):
             self.current_folders = self.server.folders
         else:
-             # Just in case it's used standalone without the threaded wrapper
-             self.current_folders = {"INBOX": []}
-        
-        self.retry_state = {} # key -> count
+            # Just in case it's used standalone without the threaded wrapper
+            self.current_folders = {"INBOX": []}
+
+        self.retry_state = {}  # key -> count
 
         while True:
             try:
@@ -38,18 +37,19 @@ class MockIMAPHandler(socketserver.StreamRequestHandler):
                 tag = parts[0]
                 cmd = parts[1].upper()
                 args = parts[2] if len(parts) > 2 else ""
-                
+
                 # Check for RETRY_N injection in args (for testing imap_retry)
                 # Pattern: RETRY_N where N is integer
                 import re
-                retry_match = re.search(r'RETRY_(\d+)', args)
+
+                retry_match = re.search(r"RETRY_(\d+)", args)
                 if retry_match:
                     count = int(retry_match.group(1))
                     # Create a unique key for this command invocation context
                     # Just using command + args is roughly sufficient
                     key = f"{cmd}_{args}"
                     current_fails = self.retry_state.get(key, 0)
-                    
+
                     if current_fails < count:
                         # Logic Fix: Only increment if we are going to fail
                         self.retry_state[key] = current_fails + 1
@@ -59,11 +59,12 @@ class MockIMAPHandler(socketserver.StreamRequestHandler):
 
                 if cmd == "LOGIN":
                     self.send_response(tag, "OK LOGIN completed")
-                
+
                 elif cmd == "APPEND":
                     # Check for literal size
                     import re
-                    size_match = re.search(r'\{(\d+)\}$', args)
+
+                    size_match = re.search(r"\{(\d+)\}$", args)
                     data = b""
                     if size_match:
                         size = int(size_match.group(1))
@@ -72,10 +73,10 @@ class MockIMAPHandler(socketserver.StreamRequestHandler):
                         self.wfile.flush()
                         # Read data
                         data = self.rfile.read(size)
-                        
+
                     # Extract mailbox name to store the message
                     # Simplistic parsing: check for quoted or unquoted first argument
-                    mailbox = "INBOX" # Default fallback
+                    mailbox = "INBOX"  # Default fallback
                     clean_args = args.lstrip()
                     if clean_args.startswith('"'):
                         end_quote = clean_args.find('"', 1)
@@ -83,18 +84,18 @@ class MockIMAPHandler(socketserver.StreamRequestHandler):
                             mailbox = clean_args[1:end_quote]
                     else:
                         mailbox = clean_args.split(" ")[0]
-                    
+
                     if mailbox not in self.current_folders:
                         self.current_folders[mailbox] = []
 
                     # Parse flags if present: look for (...)
                     msg_flags = set()
-                    flag_match = re.search(r'\(([^)]+)\)', args)
+                    flag_match = re.search(r"\(([^)]+)\)", args)
                     if flag_match:
                         # e.g. (\Seen \Deleted)
                         flag_content = flag_match.group(1)
                         msg_flags = set(flag_content.split())
-                    
+
                     # Store message
                     new_uid = len(self.current_folders[mailbox]) + 1
                     msg_obj = {"uid": new_uid, "flags": msg_flags, "content": data}
@@ -118,9 +119,9 @@ class MockIMAPHandler(socketserver.StreamRequestHandler):
                     _ = self.rfile.readline()
                     # Also consume potential retry line? No.
                     self.send_response(tag, "OK AUTHENTICATE completed")
-                
+
                 elif cmd == "NOOP":
-                     self.send_response(tag, "OK NOOP completed")
+                    self.send_response(tag, "OK NOOP completed")
 
                 elif cmd == "LIST":
                     for folder in self.current_folders:
@@ -129,35 +130,35 @@ class MockIMAPHandler(socketserver.StreamRequestHandler):
 
                 elif cmd == "SELECT":
                     folder = args.strip().strip('"')
-                    
+
                     # For retry testing: if folder starts with NO, fail immediately
                     if folder.startswith("NO"):
-                         # e.g. "NO [UNAVAILABLE]"
-                         self.send_response(tag, folder)
-                         continue
-                    
+                        # e.g. "NO [UNAVAILABLE]"
+                        self.send_response(tag, folder)
+                        continue
+
                     # Allow RETRY_N folders to succeed if they passed the retry intercept logic
                     is_retry_folder = "RETRY_" in folder
 
                     if folder in self.current_folders or is_retry_folder:
                         self.selected_folder = folder
-                        count = len(self.current_folders.get(folder, [])) # Default empty for retry folders
+                        count = len(self.current_folders.get(folder, []))  # Default empty for retry folders
                         self.wfile.write(f"* {count} EXISTS\r\n".encode())
                         self.wfile.write(f"* {count} RECENT\r\n".encode())
                         self.wfile.write(b"* FLAGS (\\Seen \\Answered \\Flagged \\Deleted \\Draft)\r\n")
                         self.wfile.write(b"* OK [UIDVALIDITY 1] UIDs valid\r\n")
                         self.send_response(tag, "OK [READ-WRITE] SELECT completed")
                     elif folder == "EMPTY":
-                       # Special case for "empty_data" test in retry
-                       self.wfile.write(b"* 0 EXISTS\r\n")
-                       self.send_response(tag, "OK SELECT completed")
+                        # Special case for "empty_data" test in retry
+                        self.wfile.write(b"* 0 EXISTS\r\n")
+                        self.send_response(tag, "OK SELECT completed")
                     else:
                         self.send_response(tag, "NO [NONEXISTENT] Folder not found")
 
                 elif cmd == "EXAMINE":
                     # EXAMINE is like SELECT but read-only
                     folder = args.strip().strip('"')
-                    
+
                     is_retry_folder = "RETRY_" in folder
 
                     if folder in self.current_folders or is_retry_folder:
@@ -506,6 +507,7 @@ class MockIMAPHandler(socketserver.StreamRequestHandler):
             except Exception as e:
                 print(f"MockServer EXCEPTION: {e}")
                 import traceback
+
                 traceback.print_exc()
                 break
 
@@ -535,15 +537,15 @@ class MockIMAPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
 def start_server_thread(port=0, initial_folders=None):
     # Use port 0 to let OS select free port
     if isinstance(port, dict):
-         # Handle legacy call where port was inadvertently passed as dict
-         initial_folders = port
-         port = 0
-         
+        # Handle legacy call where port was inadvertently passed as dict
+        initial_folders = port
+        port = 0
+
     server = MockIMAPServer(("localhost", port), MockIMAPHandler, initial_folders)
-    
+
     # Get the actual port if 0 was used
     actual_port = server.server_address[1]
-    
+
     t = threading.Thread(target=server.serve_forever)
     t.daemon = True
     t.start()


### PR DESCRIPTION
This pull request introduces robust retry logic for IMAP operations to handle transient server errors (such as "Server Busy" or "UNAVAILABLE") with exponential backoff, improving reliability in the face of flaky IMAP servers. The main changes include the addition of a transparent proxy wrapper for IMAP connections, integration of this wrapper throughout the codebase, improved error handling and logging for IMAP operations, and comprehensive unit tests for the new retry logic. Additionally, the mock IMAP server and test infrastructure have been updated to support and validate these behaviors.

**IMAP Retry Logic and Integration**

* Added `imap_retry.py` with a `ConnectionProxy` class that transparently retries IMAP commands (like `select`, `fetch`, `append`, etc.) on transient server errors using exponential backoff. This proxy inspects IMAP responses for known transient error patterns and retries the operation up to a configurable number of times, logging each retry attempt.
* Updated `get_imap_connection` in `imap_common.py` to return a `ConnectionProxy` instead of a raw IMAP connection, ensuring all downstream IMAP operations benefit from automatic retry logic.
* Imported the new `imap_retry` module in `imap_common.py` to enable the use of the retry proxy.

**Error Handling and Logging Improvements**

* Enhanced error handling in `append_email` and `sync_flags_on_existing` in `imap_common.py` to log detailed error messages (including server responses) when IMAP operations fail, aiding in debugging and monitoring. [[1]](diffhunk://#diff-787096578e7e449374fe68a51d12b00b707bae5f8f4c3208e02016423d743539L216-R219) [[2]](diffhunk://#diff-787096578e7e449374fe68a51d12b00b707bae5f8f4c3208e02016423d743539L653-R661)
* Updated `process_single_uid` in `migrate_imap_emails.py` to check the result of `append_email` and log success or failure for each message and label application. [[1]](diffhunk://#diff-3941c1f42456149660bbee8b79d076b7b75e000bd91ecbabc1746d464a8300e2L286-R300) [[2]](diffhunk://#diff-3941c1f42456149660bbee8b79d076b7b75e000bd91ecbabc1746d464a8300e2L331-R347)

**Testing Infrastructure and Coverage**

* Added `test/test_imap_retry.py` with comprehensive tests for the retry logic, including detection of transient errors, correct retry/backoff behavior, pass-through for non-retryable methods, and validation of configuration parameters.
* Modified the mock IMAP server (`tools/mock_imap_server.py`) to support simulated transient errors and correct stateful retry behavior, as well as proper handling of the `APPEND` command for realistic testing. [[1]](diffhunk://#diff-09c8758af889b9281d705975ecd91b0891eccc24d7c72b7ac8ebbd2e763d2572L1) [[2]](diffhunk://#diff-09c8758af889b9281d705975ecd91b0891eccc24d7c72b7ac8ebbd2e763d2572R17-R25) [[3]](diffhunk://#diff-09c8758af889b9281d705975ecd91b0891eccc24d7c72b7ac8ebbd2e763d2572R41-R107)
* Updated test fixtures and server shutdown logic in `test/conftest.py` to align with changes in how mock servers are managed and to ensure proper resource cleanup. [[1]](diffhunk://#diff-7dae78a00d8d69422a3bfbde96c7c5d794eede504a0df763853896a1ba1b5ff2L36-R61) [[2]](diffhunk://#diff-7dae78a00d8d69422a3bfbde96c7c5d794eede504a0df763853896a1ba1b5ff2L85-R106)

**Test Adjustments for Proxy Integration**

* Adjusted assertions in `test/test_count_imap_emails.py` to account for the fact that `get_imap_connection` now returns a proxy rather than a raw IMAP connection. [[1]](diffhunk://#diff-17caa53368a28f06fca1a4409e89bb1e44b5e98736f56460cddabcfb89c4fc22L199) [[2]](diffhunk://#diff-17caa53368a28f06fca1a4409e89bb1e44b5e98736f56460cddabcfb89c4fc22L220)

Related to now closed #31 