### PR TITLE
Fix import path for CI build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,5 +153,5 @@ jobs:
 
       - name: Check imports
         run: |
-          cd src && python -c "import imap_common; import migrate_imap_emails; import backup_imap_emails; import restore_imap_emails; import count_imap_emails; import compare_imap_folders"
+          cd src && python -c "import utils.imap_common; import migrate_imap_emails; import backup_imap_emails; import restore_imap_emails; import count_imap_emails; import compare_imap_folders"
           echo "All imports successful"


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow to fix a Python import path. The change ensures that the `imap_common` module is imported from the correct `utils` subpackage during the import check step.

- CI workflow: Updated the import path for `imap_common` to `utils.imap_common` in the Python import check command in `.github/workflows/ci.yml` to reflect its location within the `utils` subpackage.