### PR TITLE
fix(auth/microsoft): support personal Microsoft accounts (hotmail/outlook/live/msn)

### DIFF
--- a/src/auth/oauth2_microsoft.py
+++ b/src/auth/oauth2_microsoft.py
@@ -75,6 +75,16 @@ def discover_tenant(email):
     if domain in _tenant_cache:
         return _tenant_cache[domain]
 
+    # Personal Microsoft accounts (live.com identity provider) live in the
+    # "consumers" tenant. Auto-discovery via login.microsoftonline.com for
+    # these domains returns a Microsoft-internal work/school tenant that
+    # rejects personal accounts with AADSTS50020. Short-circuit here.
+    if domain in ("hotmail.com", "outlook.com", "live.com", "msn.com",
+                  "hotmail.co.uk", "outlook.co.uk", "live.co.uk",
+                  "hotmail.fr", "outlook.fr", "hotmail.de", "outlook.de"):
+        _tenant_cache[domain] = "consumers"
+        return "consumers"
+
     domain_quoted = urllib.parse.quote(domain, safe=".-")
     path = f"/{domain_quoted}/.well-known/openid-configuration"
 
@@ -120,7 +130,10 @@ def acquire_token(client_id, email):
         authority = f"{authority_base.rstrip('/')}/{tenant_id}"
     else:
         authority = f"https://login.microsoftonline.com/{tenant_id}"
-    scopes = ["https://outlook.office365.com/IMAP.AccessAsUser.All"]
+    # Personal accounts (consumers tenant) require the outlook.office.com
+    # resource URL, not outlook.office365.com, or AADSTS70011 fires.
+    resource_host = "outlook.office.com" if tenant_id == "consumers" else "outlook.office365.com"
+    scopes = [f"https://{resource_host}/IMAP.AccessAsUser.All"]
 
     # Reuse cached MSAL app so acquire_token_silent can access refresh tokens
     cache_key = (client_id, tenant_id)


### PR DESCRIPTION
## Summary

The current Microsoft OAuth flow only works for work/school accounts. Personal Microsoft accounts (hotmail.com, outlook.com, live.com, msn.com) fail in two distinct places with cryptic `AADSTS` errors that make root-causing painful.

Both issues reproduce reliably against any personal Microsoft account with the Thunderbird public client ID (`9e5f94bc-e8a4-4e73-b8be-63364c29d753`).

## Bug 1: \`AADSTS50020\` — tenant discovery returns the wrong tenant

\`discover_tenant()\` queries \`login.microsoftonline.com/<domain>/.well-known/openid-configuration\` and extracts the tenant UUID from the discovered issuer. For personal domains this returns a Microsoft-internal work/school tenant (\`9cd80435-793b-4f48-844b-6b3f37d1c1f3\`), which then rejects the personal account at sign-in:

\`\`\`
AADSTS50020: User account 'x@hotmail.com' from identity provider 'live.com'
does not exist in tenant '' and cannot access the application '<client_id>'
in that tenant.
\`\`\`

Personal accounts live in the special \`consumers\` tenant, not a UUID.

## Bug 2: \`AADSTS70011\` — scope resource URL is wrong for consumers

Even after routing to the \`consumers\` tenant, the hardcoded scope \`https://outlook.office365.com/IMAP.AccessAsUser.All\` is rejected:

\`\`\`
AADSTS70011: The provided resource value for the input parameter 'scope' is not valid.
\`\`\`

Personal accounts (v2.0 endpoint) require the \`outlook.office.com\` resource URL, not \`outlook.office365.com\`.

## Fix

Two minimal, targeted changes in \`src/auth/oauth2_microsoft.py\`:

1. **Short-circuit \`discover_tenant()\`** to return \`\"consumers\"\` for a shortlist of known personal Microsoft domains. Falls through to the existing discovery path for everything else, so work/school behavior is untouched. Also avoids an unnecessary network round-trip.

2. **Conditionally select the scope resource host** based on the resolved tenant: \`outlook.office.com\` for \`consumers\`, \`outlook.office365.com\` otherwise.

Domain shortlist: \`hotmail.com\`, \`outlook.com\`, \`live.com\`, \`msn.com\`, plus common regional variants (\`.co.uk\`, \`.fr\`, \`.de\`). Extendable.

## Test plan

- [x] Verified end-to-end against a personal \`hotmail.com\` account
- [x] \`imap_count.py\` successfully enumerates all folders (24) and prints per-folder counts (47,897 total messages)
- [x] Device-code flow completes with URL \`https://www.microsoft.com/link\`
- [x] Before the fix: both \`AADSTS50020\` and \`AADSTS70011\` reproduce reliably
- [x] Work/school accounts should be unaffected (control-flow untouched for non-shortlisted domains)

## Backwards compatibility

No behavior change for work/school accounts — the shortlist check is at the top of \`discover_tenant()\` and only matches personal Microsoft domains, so existing users are unaffected. The scope selection is tenant-conditional, defaulting to \`outlook.office365.com\` as before.