### PR TITLE
feat(auth/microsoft): persist MSAL token cache to disk (SerializableTokenCache)

### DIFF
--- a/src/auth/oauth2_microsoft.py
+++ b/src/auth/oauth2_microsoft.py
@@ -120,18 +120,26 @@ def _load_cache(cache_path, msal_module):
 
 
 def _save_cache(cache, cache_path):
-    """Persist the cache to disk if it changed, with restrictive permissions."""
+    """Persist the cache to disk if it changed, with restrictive permissions.
+
+    On POSIX, the file is created with mode 0600 atomically (via os.open with
+    the O_CREAT flag + mode arg), so refresh-token bytes never touch a
+    world-readable inode. Windows ignores the mode arg — its ACL model is
+    handled separately and defaults to inheriting the parent directory ACL,
+    which is typically the user's profile directory.
+    """
     if not cache.has_state_changed:
         return
     try:
-        with open(cache_path, "w", encoding="utf-8") as f:
+        # os.open with O_CREAT|O_WRONLY|O_TRUNC and mode 0o600 ensures POSIX
+        # never sees a world-readable moment between file creation and chmod.
+        fd = os.open(
+            cache_path,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            0o600,
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(cache.serialize())
-        # Restrict permissions on POSIX. Windows uses ACLs; chmod is a no-op
-        # there but harmless.
-        try:
-            os.chmod(cache_path, 0o600)
-        except OSError:
-            pass
     except OSError as e:
         print(f"Warning: Could not save MSAL token cache to {cache_path}: {e}")
 

--- a/src/auth/oauth2_microsoft.py
+++ b/src/auth/oauth2_microsoft.py
@@ -96,14 +96,57 @@ def discover_tenant(email):
     return None
 
 
+def _msal_cache_path_for(email):
+    """
+    Per-account MSAL token cache path.
+    Contains refresh tokens — permissions restricted to owner (POSIX).
+    Environment override: OAUTH2_MICROSOFT_CACHE_DIR.
+    """
+    cache_dir = os.getenv("OAUTH2_MICROSOFT_CACHE_DIR") or os.path.expanduser("~")
+    safe = re.sub(r"[^a-zA-Z0-9]", "_", email.lower())
+    return os.path.join(cache_dir, f".msal-imap-migrate-{safe}.json")
+
+
+def _load_cache(cache_path, msal_module):
+    """Load a SerializableTokenCache from disk, if it exists."""
+    cache = msal_module.SerializableTokenCache()
+    if os.path.exists(cache_path):
+        try:
+            with open(cache_path, "r", encoding="utf-8") as f:
+                cache.deserialize(f.read())
+        except (OSError, ValueError) as e:
+            print(f"Warning: Could not load MSAL token cache from {cache_path}: {e}")
+    return cache
+
+
+def _save_cache(cache, cache_path):
+    """Persist the cache to disk if it changed, with restrictive permissions."""
+    if not cache.has_state_changed:
+        return
+    try:
+        with open(cache_path, "w", encoding="utf-8") as f:
+            f.write(cache.serialize())
+        # Restrict permissions on POSIX. Windows uses ACLs; chmod is a no-op
+        # there but harmless.
+        try:
+            os.chmod(cache_path, 0o600)
+        except OSError:
+            pass
+    except OSError as e:
+        print(f"Warning: Could not save MSAL token cache to {cache_path}: {e}")
+
+
 def acquire_token(client_id, email):
     """
     Acquires a Microsoft OAuth2 access token using the MSAL device code flow.
     Auto-discovers tenant ID from the email domain.
     Requires the 'msal' package: pip install msal
 
-    On subsequent calls, silently refreshes the token using the cached MSAL app
-    (which holds the refresh token in its in-memory cache).
+    The token cache is persisted to disk (per email, in the user's home dir
+    by default; override with OAUTH2_MICROSOFT_CACHE_DIR). After the first
+    interactive device-code approval, subsequent process invocations reuse
+    the refresh token silently — enabling cron use. Cache files contain
+    refresh tokens (secrets) and are written with mode 0600 on POSIX.
     """
     tenant_id = discover_tenant(email)
     if not tenant_id:
@@ -122,13 +165,18 @@ def acquire_token(client_id, email):
         authority = f"https://login.microsoftonline.com/{tenant_id}"
     scopes = ["https://outlook.office365.com/IMAP.AccessAsUser.All"]
 
-    # Reuse cached MSAL app so acquire_token_silent can access refresh tokens
-    cache_key = (client_id, tenant_id)
+    # Load persistent cache — enables non-interactive cron use.
+    cache_path = _msal_cache_path_for(email)
+    cache = _load_cache(cache_path, msal)
+
+    # Reuse cached MSAL app so acquire_token_silent can access refresh tokens.
+    # Include email in the key so different accounts don't share app state.
+    cache_key = (client_id, tenant_id, email)
     if cache_key in _msal_app_cache:
         app = _msal_app_cache[cache_key]
     else:
         print(f"Discovered Microsoft tenant: {tenant_id}")
-        app = msal.PublicClientApplication(client_id, authority=authority)
+        app = msal.PublicClientApplication(client_id, authority=authority, token_cache=cache)
         _msal_app_cache[cache_key] = app
 
     # Try cached/refreshed token first (handles refresh tokens automatically)
@@ -136,6 +184,7 @@ def acquire_token(client_id, email):
     if accounts:
         result = app.acquire_token_silent(scopes, account=accounts[0])
         if result and "access_token" in result:
+            _save_cache(cache, cache_path)  # persist any refresh-token rotation
             return result["access_token"]
 
     # Fall back to device code flow (first call or if refresh fails)
@@ -148,6 +197,7 @@ def acquire_token(client_id, email):
     result = app.acquire_token_by_device_flow(flow)
 
     if "access_token" in result:
+        _save_cache(cache, cache_path)  # persist newly-acquired refresh token
         return result["access_token"]
 
     print(f"Error: Could not acquire token: {result.get('error_description', 'Unknown error')}")


### PR DESCRIPTION
## Summary

The current Microsoft OAuth flow uses an in-memory-only MSAL token cache. Every new Python process invocation triggers a fresh device-code prompt, blocking cron / scheduled use of any of the tools (imap_count, imap_migrate, imap_compare).

This PR wires up MSAL's [\`SerializableTokenCache\`](https://msal-python.readthedocs.io/en/latest/#msal.SerializableTokenCache) with per-account disk persistence, so the first device-code approval is remembered and subsequent invocations complete silently via the refresh token.

## Change

- New helpers \`_msal_cache_path_for(email)\`, \`_load_cache\`, \`_save_cache\` in \`src/auth/oauth2_microsoft.py\`.
- Cache path defaults to \`~/.msal-imap-migrate-<safe_email>.json\`; overridable via \`OAUTH2_MICROSOFT_CACHE_DIR\`.
- Cache is attached to \`PublicClientApplication(..., token_cache=cache)\`.
- \`_save_cache\` writes with \`chmod 0600\` on POSIX after any acquire that changed the cache state.
- The module-level MSAL app cache key now includes \`email\` so multi-account use doesn't share state.

## Why it matters

**Before:** every run needs a human at \`https://www.microsoft.com/link\`. Cron/systemd/Task Scheduler use is impossible.

**After:** first run prompts once. Subsequent runs are silent. Refresh tokens are long-lived (Microsoft default: 90 days rolling), so cron/scheduled sync runs indefinitely.

This unlocks the runbook pattern the README already gestures at (\"After the one-time device-code approval, MSAL's cached refresh token makes runs non-interactive\").

## Security

- Cache file contains an OAuth refresh token — a bearer credential.
- Written with mode 0600 on POSIX (owner read/write only). Windows uses ACLs; \`os.chmod\` is a no-op there.
- Default path is the user's home directory. Deployments that need isolation (service accounts, containers, multi-tenant hosts) can set \`OAUTH2_MICROSOFT_CACHE_DIR\`.
- No credentials logged or printed.

## Test plan

- [x] First run prompts for device code (unchanged from current behavior)
- [x] Second run silently reuses the refresh token, no prompt
- [x] Cache file has mode 0600 on POSIX
- [x] Missing cache handled gracefully (creates on first successful acquire)
- [x] Malformed cache handled gracefully (warns + falls back to device flow)
- [x] \`OAUTH2_MICROSOFT_CACHE_DIR\` env override respected
- [x] Multiple accounts on the same host use distinct cache files (verified on a two-account setup)
- [x] Windows Scheduled Task running \`imap_migrate.py\` every 30 min completes silently

## Backwards compatibility

Purely additive — no existing behavior changes for anyone. The first-time device-code flow is unchanged; the cache is created only after a successful acquire. Users who don't want persistent caching can delete the file (falls back to prompting) or point \`OAUTH2_MICROSOFT_CACHE_DIR\` at a nonexistent location.

## Interaction with #42

Independent of #42 (\"support personal Microsoft accounts\"). This PR benefits work/school and personal accounts equally. Can be merged in either order.