### PR TITLE
feat: Add ability to use a `.env` file rather than editing environment variables directly

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Source Account
+SRC_IMAP_HOST="imap.gmail.com"
+SRC_IMAP_USERNAME="source@gmail.com"
+SRC_IMAP_PASSWORD="your-app-password"
+
+# Destination Account
+DEST_IMAP_HOST="imap.destination.com"
+DEST_IMAP_USERNAME="dest@domain.com"
+DEST_IMAP_PASSWORD="dest-app-password"
+
+# OAuth2 (Optional - instead of password)
+SRC_OAUTH2_CLIENT_ID="your-client-id"
+SRC_OAUTH2_CLIENT_SECRET="your-client-secret"  # Required for Google
+DEST_OAUTH2_CLIENT_ID="your-dest-client-id"
+DEST_OAUTH2_CLIENT_SECRET="your-dest-client-secret"  # Required for Google
+
+# Options (Optional)
+DELETE_FROM_SOURCE="false"  # Set to "true" to delete from source after copy
+DEST_DELETE="false"         # Set to "true" to delete orphans from destination (sync mode)
+PRESERVE_FLAGS="false"      # Set to "true" to preserve IMAP flags (read/starred/etc)
+GMAIL_MODE="false"          # Set to "true" for Gmail mode (All Mail + label application)
+MAX_WORKERS=4               # Number of parallel threads
+BATCH_SIZE=10               # Emails per batch

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ This repository contains a set of Python scripts designed to migrate emails betw
 - **No external installations required for basic (password) authentication.**
   The scripts use only the Python Standard Library for standard IMAP login.
 
+-  **Optional:** To use a `.env` file, install the dotenv package as well:
+  - **`pip install python-dotenv`
+
 - **Optional: OAuth2 authentication** requires one additional package depending on your provider:
   - **Microsoft (Outlook/Office 365):** `pip install msal`
   - **Google (Gmail):** `pip install google-auth-oauthlib`
@@ -178,7 +181,36 @@ You can configure the scripts using **Environment Variables** (recommended for s
    python imap_migrate.py
    ```
 
-### Method 2: Command Line Arguments (Overrides)
+### Method 2: `.env` File
+
+Rather than setting environment variables directly, you can use a `.env` file. A template containing supported configuration options is provided in `.env.example`.
+
+1. **Create a `.env` file:**
+   ```bash
+   cp .env.example .env
+   ```
+
+   On Windows (PowerShell):
+   ```powershell
+   Copy-Item .env.example .env
+   ```
+
+2. **Edit `.env`** and update the values for your environment.
+
+3. **Run:**
+   ```bash
+   python3 imap_migrate.py
+   ```
+
+   On Windows (PowerShell):
+   ```powershell
+   python imap_migrate.py
+   ```
+
+> **Note:** If a `.env` file is present, it will be loaded automatically at startup. `.env.example` is provided as a template and should be copied rather than modified directly.
+
+
+### Method 3: Command Line Arguments (Overrides)
 All scripts support command-line arguments which take precedence over environment variables.
 
 **Migration:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
     "msal",
 ]
 
+[project.optional-dependencies]
+dotenv = ["python-dotenv>=1.2.1"]
+
 [project.urls]
 "Homepage" = "https://github.com/jcallico/imap-migration-tools"
 "Bug Tracker" = "https://github.com/jcallico/imap-migration-tools/issues"

--- a/src/imap_backup.py
+++ b/src/imap_backup.py
@@ -60,6 +60,7 @@ from auth import imap_oauth2
 from core import imap_session
 from providers import provider_exchange, provider_gmail
 from utils import imap_common
+from utils.dotenv_loader import load_dotenv
 
 # Defaults
 MAX_WORKERS = 10
@@ -681,7 +682,7 @@ def backup_folder(src_main, folder_name, local_base_path, src_conf, dest_delete=
 def main():
     parser = argparse.ArgumentParser(description="Backup IMAP emails to local .eml files.")
     parser.add_argument("--version", action="version", version=f"%(prog)s {imap_common.get_version()}")
-
+    load_dotenv()
     # Source
     default_src_host = os.getenv("SRC_IMAP_HOST")
     default_src_user = os.getenv("SRC_IMAP_USERNAME")

--- a/src/imap_compare.py
+++ b/src/imap_compare.py
@@ -63,6 +63,7 @@ import sys
 
 from auth import imap_oauth2
 from utils import imap_common
+from utils.dotenv_loader import load_dotenv
 
 
 def get_email_count(conn, folder_name):
@@ -86,6 +87,7 @@ def get_email_count(conn, folder_name):
 
 
 def main():
+    load_dotenv()
     default_src_path = os.getenv("SRC_LOCAL_PATH")
     default_dest_path = os.getenv("DEST_LOCAL_PATH")
 

--- a/src/imap_count.py
+++ b/src/imap_count.py
@@ -47,6 +47,7 @@ import os
 import sys
 from typing import Optional
 
+from utils.dotenv_loader import load_dotenv
 from auth import imap_oauth2
 from utils import imap_common
 
@@ -135,6 +136,7 @@ def count_local_emails(local_path: str) -> None:
 
 
 def main(argv: Optional[list[str]] = None) -> None:
+    load_dotenv()
     # Phase 1: determine whether we're in local mode (--path)
     default_path = os.getenv("BACKUP_LOCAL_PATH") or os.getenv("SRC_LOCAL_PATH")
     pre_parser = argparse.ArgumentParser(add_help=False)

--- a/src/imap_migrate.py
+++ b/src/imap_migrate.py
@@ -135,6 +135,7 @@ from auth import imap_oauth2
 from core import imap_session
 from providers import provider_exchange, provider_gmail
 from utils import imap_common, restore_cache
+from utils.dotenv_loader import load_dotenv
 
 # Configuration defaults
 DELETE_FROM_SOURCE_DEFAULT = False
@@ -760,6 +761,8 @@ def main():
 
     # Positional arg for folder (optional) to keep backward compatibility with previous quick-fix
     parser.add_argument("folder", nargs="?", help="Specific folder to migrate (e.g. '[Gmail]/Important')")
+
+    load_dotenv()
 
     # Source args
     default_src_host = os.getenv("SRC_IMAP_HOST")

--- a/src/imap_restore.py
+++ b/src/imap_restore.py
@@ -62,7 +62,7 @@ from auth import imap_oauth2
 from core import imap_session
 from providers import provider_gmail
 from utils import imap_common, restore_cache
-
+from utils.dotenv_loader import load_dotenv
 
 class UploadResult(Enum):
     """Result of an email upload operation."""
@@ -693,7 +693,7 @@ def restore_gmail_with_labels(
 def main():
     parser = argparse.ArgumentParser(description="Restore IMAP emails from local .eml files.")
     parser.add_argument("--version", action="version", version=f"%(prog)s {imap_common.get_version()}")
-
+    load_dotenv()
     # Source (Local Path)
     env_path = os.getenv("BACKUP_LOCAL_PATH")
     parser.add_argument(

--- a/src/utils/dotenv_loader.py
+++ b/src/utils/dotenv_loader.py
@@ -1,0 +1,8 @@
+def load_dotenv():
+    """Load a .env file if python-dotenv is installed; silently skip if not."""
+    try:
+        from dotenv import load_dotenv as _load_dotenv
+
+        _load_dotenv()
+    except ImportError:
+        pass


### PR DESCRIPTION
I found this repo very useful for my email migration efforts. Thank you so much for taking the time to create it. 

I decided to use a `.env` file rather than making a large command prefixing the env vars (e.g. MY_VAR=value my-command) or setting the variables from the command line. I made it optional, and added information in the README on how to use python-dotenv.

I think others might find it useful as well since there are a lot of env vars and find it easier to edit the `.env` file rather than creating a large command and editing that in the command line.

