### PR TITLE
Add`.env` configuration support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Source Account
+SRC_IMAP_HOST="imap.gmail.com"
+SRC_IMAP_USERNAME="source@gmail.com"
+SRC_IMAP_PASSWORD="your-app-password"
+
+# Destination Account
+DEST_IMAP_HOST="imap.destination.com"
+DEST_IMAP_USERNAME="dest@domain.com"
+DEST_IMAP_PASSWORD="dest-app-password"
+
+# OAuth2 (Optional - instead of password)
+SRC_OAUTH2_CLIENT_ID="your-client-id"
+SRC_OAUTH2_CLIENT_SECRET="your-client-secret"  # Required for Google
+DEST_OAUTH2_CLIENT_ID="your-dest-client-id"
+DEST_OAUTH2_CLIENT_SECRET="your-dest-client-secret"  # Required for Google
+
+# Options (Optional)
+DELETE_FROM_SOURCE="false"  # Set to "true" to delete from source after copy
+DEST_DELETE="false"         # Set to "true" to delete orphans from destination (sync mode)
+PRESERVE_FLAGS="false"      # Set to "true" to preserve IMAP flags (read/starred/etc)
+GMAIL_MODE="false"          # Set to "true" for Gmail mode (All Mail + label application)
+MAX_WORKERS=4               # Number of parallel threads
+BATCH_SIZE=10               # Emails per batch

--- a/.env.example
+++ b/.env.example
@@ -1,23 +1,47 @@
-# Source Account
+# Source Account (used by backup, migration, and comparison)
 SRC_IMAP_HOST="imap.gmail.com"
 SRC_IMAP_USERNAME="source@gmail.com"
 SRC_IMAP_PASSWORD="your-app-password"
 
-# Destination Account
+# Destination Account (used by restore, migration, and comparison)
 DEST_IMAP_HOST="imap.destination.com"
 DEST_IMAP_USERNAME="dest@domain.com"
 DEST_IMAP_PASSWORD="dest-app-password"
 
-# OAuth2 (Optional - instead of password)
+# OAuth2 (optional; use instead of the corresponding password)
 SRC_OAUTH2_CLIENT_ID="your-client-id"
 SRC_OAUTH2_CLIENT_SECRET="your-client-secret"  # Required for Google
 DEST_OAUTH2_CLIENT_ID="your-dest-client-id"
 DEST_OAUTH2_CLIENT_SECRET="your-dest-client-secret"  # Required for Google
 
-# Options (Optional)
-DELETE_FROM_SOURCE="false"  # Set to "true" to delete from source after copy
-DEST_DELETE="false"         # Set to "true" to delete orphans from destination (sync mode)
-PRESERVE_FLAGS="false"      # Set to "true" to preserve IMAP flags (read/starred/etc)
-GMAIL_MODE="false"          # Set to "true" for Gmail mode (All Mail + label application)
-MAX_WORKERS=4               # Number of parallel threads
-BATCH_SIZE=10               # Emails per batch
+# Local paths
+BACKUP_LOCAL_PATH="./my_backup"  # Backup destination; restore/count source
+SRC_LOCAL_PATH=""                 # Local comparison source
+DEST_LOCAL_PATH=""                # Local comparison destination
+
+# imap-count aliases (optional; SRC_IMAP_* values are used as fallbacks)
+IMAP_HOST=""
+IMAP_USERNAME=""
+IMAP_PASSWORD=""
+OAUTH2_CLIENT_ID=""
+OAUTH2_CLIENT_SECRET=""
+
+# Shared options
+MAX_WORKERS=4       # Number of parallel threads
+BATCH_SIZE=10       # Emails per batch
+DEST_DELETE="false"  # Delete destination-only messages/files in sync mode
+
+# Migration options
+DELETE_FROM_SOURCE="false"  # Delete source messages after a successful copy
+PRESERVE_LABELS="false"     # Preserve Gmail labels (backup and migration)
+PRESERVE_FLAGS="false"      # Preserve IMAP flags (read/starred/etc.)
+GMAIL_MODE="false"          # Use Gmail All Mail mode and apply labels
+MIGRATE_ONLY_FOLDER=""      # Migrate a single folder when no positional folder is given
+
+# Backup options
+MANIFEST_ONLY="false"  # Build the Gmail labels manifest without downloading messages
+
+# Restore options
+APPLY_LABELS="false"  # Apply Gmail labels from labels_manifest.json
+APPLY_FLAGS="false"   # Apply IMAP flags from labels_manifest.json
+FULL_RESTORE="false"  # Process all messages and sync existing messages' labels/flags

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cov
+          pip install pytest pytest-cov python-dotenv
 
       - name: Run tests with coverage
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# IMAP Migration Tools Contributor Guide
+
+## Project layout
+
+- `src/imap_backup.py`, `src/imap_restore.py`, `src/imap_migrate.py`, `src/imap_count.py`, and `src/imap_compare.py` are the primary CLI entry points.
+- `src/*_imap_*.py` files are compatibility wrappers for older script names. Keep them working when changing an entry point.
+- Shared IMAP, authentication, provider, and cache logic belongs in `src/core/`, `src/auth/`, `src/providers/`, and `src/utils/`.
+- Tests mirror the source layout. CLI integration tests live in the corresponding `test/test_imap_*.py` file.
+
+## Development workflow
+
+Use Python 3.9+ and run commands from the repository root. The source tree is not installed during tests, so include `PYTHONPATH=src` when invoking pytest directly.
+
+```bash
+python3 -m venv .venv
+.venv/bin/python -m pip install -r requirements.txt
+.venv/bin/python -m pip install python-dotenv  # required by .env integration tests
+PYTHONPATH=src .venv/bin/python -m pytest test/ -v
+.venv/bin/python -m ruff check src/ tools/ test/
+.venv/bin/python -m ruff format --check src/ tools/ test/
+```
+
+`make test`, `make lint`, and `make format-check` provide the same common checks. CI also runs Bandit, a non-blocking mypy check, syntax/import checks, and tests on Python 3.9 through 3.13.
+
+Tests use local mock IMAP servers and bind loopback ports. In restricted environments, rerun them with the permission needed for local socket binding rather than changing the tests to avoid integration coverage.
+
+## Code conventions
+
+- Target Python 3.9 compatibility. Follow the Ruff configuration in `pyproject.toml` (120-column lines, double quotes, and sorted imports).
+- Use concise module and function docstrings. Place reusable behavior in the existing subsystem directories rather than duplicating it in CLI files.
+- Preserve CLI compatibility: command-line options, environment variables, and legacy wrapper scripts are public interfaces.
+- Keep sensitive values out of version control. `.env` is ignored; `.env.example` is the committed, non-secret template.
+
+## `.env` configuration
+
+- Load `.env` through `utils.dotenv.load_dotenv()` at the start of a CLI `main()` function, before reading environment variables or constructing `argparse` defaults.
+- The loader discovers `.env` from the process working directory (and its parents), not from the installed package directory.
+- Precedence is: command-line arguments, existing OS environment variables, `.env` values, then script defaults. Keep `override=False` so CI, shell, and secret-manager values remain authoritative.
+- `python-dotenv` is an optional runtime extra (`imap-migration-tools[dotenv]`). If changes affect `.env` support, update `README.md`, `.env.example`, and the CI/dev dependency setup as needed.
+- For CLI `.env` coverage, add an end-to-end case to each affected `test/test_imap_*.py` module. Use its local `dotenv_file` fixture, run the real `main()`, and assert an observable outcome against a mock IMAP server or local backup. Do not replace this with parser interception or a centralized CLI test module.
+
+## Verification before handoff
+
+Run the focused tests for changed code first, then the full suite when practical. Always run:
+
+```bash
+.venv/bin/python -m ruff check src/ tools/ test/
+.venv/bin/python -m ruff format --check src/ tools/ test/
+git diff --check
+```
+
+For user-facing changes, verify the relevant README examples and the `.env.example` template match the implementation.

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ This repository contains a set of Python scripts designed to migrate emails betw
 - **No external installations required for basic (password) authentication.**
   The scripts use only the Python Standard Library for standard IMAP login.
 
--  **Optional:** To use a `.env` file, install the dotenv package as well:
-  - **`pip install python-dotenv`
+- **Optional:** To use a `.env` file, install the `python-dotenv` package as well:
+  - `pip install python-dotenv`
 
 - **Optional: OAuth2 authentication** requires one additional package depending on your provider:
   - **Microsoft (Outlook/Office 365):** `pip install msal`
@@ -81,14 +81,19 @@ Due to recent changes in Python environments on macOS, it is recommended to use 
    brew install pipx
    pipx ensurepath
    ```
-2. Install the tools:
+2. Install the tools, including the optional `.env` support:
    ```bash
-   pipx install imap-migration-tools
+   pipx install "imap-migration-tools[dotenv]"
+   ```
+
+   If the tools are already installed, add `.env` support with:
+   ```bash
+   pipx inject imap-migration-tools python-dotenv
    ```
 
 **For Standard Environments:**
 ```bash
-pip install imap-migration-tools
+pip install "imap-migration-tools[dotenv]"
 ```
 
 Once installed via PyPI, the following commands are globally available in your terminal:
@@ -183,7 +188,7 @@ You can configure the scripts using **Environment Variables** (recommended for s
 
 ### Method 2: `.env` File
 
-Rather than setting environment variables directly, you can use a `.env` file. A template containing supported configuration options is provided in `.env.example`.
+Rather than setting environment variables directly, you can use a `.env` file. A template containing all supported configuration options is provided in `.env.example`.
 
 1. **Create a `.env` file:**
    ```bash
@@ -208,6 +213,13 @@ Rather than setting environment variables directly, you can use a `.env` file. A
    ```
 
 > **Note:** If a `.env` file is present, it will be loaded automatically at startup. `.env.example` is provided as a template and should be copied rather than modified directly.
+
+Configuration values are applied in this order, with earlier entries taking precedence:
+
+1. Command-line arguments
+2. Existing OS environment variables (such as values from your shell, CI system, or secret manager)
+3. Values in `.env`
+4. Script defaults
 
 
 ### Method 3: Command Line Arguments (Overrides)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ This repository contains a set of Python scripts designed to migrate emails betw
 - **No external installations required for basic (password) authentication.**
   The scripts use only the Python Standard Library for standard IMAP login.
 
+-  **Optional:** To use a `.env` file, install the dotenv package as well:
+  - **`pip install python-dotenv`
+
 - **Optional: OAuth2 authentication** requires one additional package depending on your provider:
   - **Microsoft (Outlook/Office 365):** `pip install msal`
   - **Google (Gmail):** `pip install google-auth-oauthlib`
@@ -178,7 +181,36 @@ You can configure the scripts using **Environment Variables** (recommended for s
    python imap_migrate.py
    ```
 
-### Method 2: Command Line Arguments (Overrides)
+### Method 2: `.env` File
+
+Rather than setting environment variables directly, you can use a `.env` file. A template containing supported configuration options is provided in `.env.example`.
+
+1. **Create a `.env` file:**
+   ```bash
+   cp .env.example .env
+   ```
+
+   On Windows (PowerShell):
+   ```powershell
+   Copy-Item .env.example .env
+   ```
+
+2. **Edit `.env`** and update the values for your environment.
+
+3. **Run:**
+   ```bash
+   python3 imap_migrate.py
+   ```
+
+   On Windows (PowerShell):
+   ```powershell
+   python imap_migrate.py
+   ```
+
+> **Note:** If a `.env` file is present, it will be loaded automatically at startup. `.env.example` is provided as a template and should be copied rather than modified directly.
+
+
+### Method 3: Command Line Arguments (Overrides)
 All scripts support command-line arguments which take precedence over environment variables.
 
 **Migration:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
     "msal",
 ]
 
+[project.optional-dependencies]
+dotenv = ["python-dotenv>=1.2.1"]
+
 [project.urls]
 "Homepage" = "https://github.com/jcallico/imap-migration-tools"
 "Bug Tracker" = "https://github.com/jcallico/imap-migration-tools/issues"

--- a/src/imap_backup.py
+++ b/src/imap_backup.py
@@ -60,7 +60,7 @@ from auth import imap_oauth2
 from core import imap_session
 from providers import provider_exchange, provider_gmail
 from utils import imap_common
-from utils.dotenv_loader import load_dotenv
+from utils.dotenv import load_dotenv
 
 # Defaults
 MAX_WORKERS = 10
@@ -680,9 +680,12 @@ def backup_folder(src_main, folder_name, local_base_path, src_conf, dest_delete=
 
 
 def main():
+    # Loading environment variables from .env file
+    load_dotenv()
+
     parser = argparse.ArgumentParser(description="Backup IMAP emails to local .eml files.")
     parser.add_argument("--version", action="version", version=f"%(prog)s {imap_common.get_version()}")
-    load_dotenv()
+
     # Source
     default_src_host = os.getenv("SRC_IMAP_HOST")
     default_src_user = os.getenv("SRC_IMAP_USERNAME")

--- a/src/imap_backup.py
+++ b/src/imap_backup.py
@@ -60,6 +60,7 @@ from auth import imap_oauth2
 from core import imap_session
 from providers import provider_exchange, provider_gmail
 from utils import imap_common
+from utils.dotenv_loader import load_dotenv
 
 # Defaults
 MAX_WORKERS = 10
@@ -681,7 +682,7 @@ def backup_folder(src_main, folder_name, local_base_path, src_conf, dest_delete=
 def main():
     parser = argparse.ArgumentParser(description="Backup IMAP emails to local .eml files.")
     parser.add_argument("--version", action="version", version=f"%(prog)s {imap_common.get_version()}")
-
+    load_dotenv()
     # Source
     default_src_host = os.getenv("SRC_IMAP_HOST")
     default_src_user = os.getenv("SRC_IMAP_USERNAME")

--- a/src/imap_compare.py
+++ b/src/imap_compare.py
@@ -63,6 +63,7 @@ import sys
 
 from auth import imap_oauth2
 from utils import imap_common
+from utils.dotenv_loader import load_dotenv
 
 
 def get_email_count(conn, folder_name):
@@ -86,6 +87,7 @@ def get_email_count(conn, folder_name):
 
 
 def main():
+    load_dotenv()
     default_src_path = os.getenv("SRC_LOCAL_PATH")
     default_dest_path = os.getenv("DEST_LOCAL_PATH")
 

--- a/src/imap_compare.py
+++ b/src/imap_compare.py
@@ -63,7 +63,7 @@ import sys
 
 from auth import imap_oauth2
 from utils import imap_common
-from utils.dotenv_loader import load_dotenv
+from utils.dotenv import load_dotenv
 
 
 def get_email_count(conn, folder_name):
@@ -87,7 +87,9 @@ def get_email_count(conn, folder_name):
 
 
 def main():
+    # Loading environment variables from .env file
     load_dotenv()
+
     default_src_path = os.getenv("SRC_LOCAL_PATH")
     default_dest_path = os.getenv("DEST_LOCAL_PATH")
 

--- a/src/imap_count.py
+++ b/src/imap_count.py
@@ -47,9 +47,9 @@ import os
 import sys
 from typing import Optional
 
-from utils.dotenv_loader import load_dotenv
 from auth import imap_oauth2
 from utils import imap_common
+from utils.dotenv import load_dotenv
 
 
 def count_emails(imap_server, username, password=None, oauth2_token=None):
@@ -136,7 +136,9 @@ def count_local_emails(local_path: str) -> None:
 
 
 def main(argv: Optional[list[str]] = None) -> None:
+    # Loading environment variables from .env file
     load_dotenv()
+
     # Phase 1: determine whether we're in local mode (--path)
     default_path = os.getenv("BACKUP_LOCAL_PATH") or os.getenv("SRC_LOCAL_PATH")
     pre_parser = argparse.ArgumentParser(add_help=False)

--- a/src/imap_count.py
+++ b/src/imap_count.py
@@ -47,6 +47,7 @@ import os
 import sys
 from typing import Optional
 
+from utils.dotenv_loader import load_dotenv
 from auth import imap_oauth2
 from utils import imap_common
 
@@ -135,6 +136,7 @@ def count_local_emails(local_path: str) -> None:
 
 
 def main(argv: Optional[list[str]] = None) -> None:
+    load_dotenv()
     # Phase 1: determine whether we're in local mode (--path)
     default_path = os.getenv("BACKUP_LOCAL_PATH") or os.getenv("SRC_LOCAL_PATH")
     pre_parser = argparse.ArgumentParser(add_help=False)

--- a/src/imap_migrate.py
+++ b/src/imap_migrate.py
@@ -135,6 +135,7 @@ from auth import imap_oauth2
 from core import imap_session
 from providers import provider_exchange, provider_gmail
 from utils import imap_common, restore_cache
+from utils.dotenv_loader import load_dotenv
 
 # Configuration defaults
 DELETE_FROM_SOURCE_DEFAULT = False
@@ -760,6 +761,8 @@ def main():
 
     # Positional arg for folder (optional) to keep backward compatibility with previous quick-fix
     parser.add_argument("folder", nargs="?", help="Specific folder to migrate (e.g. '[Gmail]/Important')")
+
+    load_dotenv()
 
     # Source args
     default_src_host = os.getenv("SRC_IMAP_HOST")

--- a/src/imap_migrate.py
+++ b/src/imap_migrate.py
@@ -135,7 +135,7 @@ from auth import imap_oauth2
 from core import imap_session
 from providers import provider_exchange, provider_gmail
 from utils import imap_common, restore_cache
-from utils.dotenv_loader import load_dotenv
+from utils.dotenv import load_dotenv
 
 # Configuration defaults
 DELETE_FROM_SOURCE_DEFAULT = False
@@ -756,13 +756,14 @@ def migrate_folder(
 
 
 def main():
+    # Loading environment variables from .env file
+    load_dotenv()
+
     parser = argparse.ArgumentParser(description="Migrate emails between IMAP accounts.")
     parser.add_argument("--version", action="version", version=f"%(prog)s {imap_common.get_version()}")
 
     # Positional arg for folder (optional) to keep backward compatibility with previous quick-fix
     parser.add_argument("folder", nargs="?", help="Specific folder to migrate (e.g. '[Gmail]/Important')")
-
-    load_dotenv()
 
     # Source args
     default_src_host = os.getenv("SRC_IMAP_HOST")

--- a/src/imap_restore.py
+++ b/src/imap_restore.py
@@ -62,7 +62,8 @@ from auth import imap_oauth2
 from core import imap_session
 from providers import provider_gmail
 from utils import imap_common, restore_cache
-from utils.dotenv_loader import load_dotenv
+from utils.dotenv import load_dotenv
+
 
 class UploadResult(Enum):
     """Result of an email upload operation."""
@@ -691,9 +692,12 @@ def restore_gmail_with_labels(
 
 
 def main():
+    # Loading environment variables from .env file
+    load_dotenv()
+
     parser = argparse.ArgumentParser(description="Restore IMAP emails from local .eml files.")
     parser.add_argument("--version", action="version", version=f"%(prog)s {imap_common.get_version()}")
-    load_dotenv()
+
     # Source (Local Path)
     env_path = os.getenv("BACKUP_LOCAL_PATH")
     parser.add_argument(

--- a/src/imap_restore.py
+++ b/src/imap_restore.py
@@ -62,7 +62,7 @@ from auth import imap_oauth2
 from core import imap_session
 from providers import provider_gmail
 from utils import imap_common, restore_cache
-
+from utils.dotenv_loader import load_dotenv
 
 class UploadResult(Enum):
     """Result of an email upload operation."""
@@ -693,7 +693,7 @@ def restore_gmail_with_labels(
 def main():
     parser = argparse.ArgumentParser(description="Restore IMAP emails from local .eml files.")
     parser.add_argument("--version", action="version", version=f"%(prog)s {imap_common.get_version()}")
-
+    load_dotenv()
     # Source (Local Path)
     env_path = os.getenv("BACKUP_LOCAL_PATH")
     parser.add_argument(

--- a/src/utils/dotenv.py
+++ b/src/utils/dotenv.py
@@ -1,0 +1,14 @@
+"""Optional loading of environment variables from a ``.env`` file."""
+
+
+def load_dotenv():
+    """Load a ``.env`` file when ``python-dotenv`` is installed."""
+    try:
+        from dotenv import find_dotenv as _find_dotenv
+        from dotenv import load_dotenv as _load_dotenv
+    except ModuleNotFoundError as exc:
+        if exc.name == "dotenv":
+            return
+        raise
+
+    _load_dotenv(_find_dotenv(usecwd=True), override=False)

--- a/src/utils/dotenv_loader.py
+++ b/src/utils/dotenv_loader.py
@@ -1,0 +1,8 @@
+def load_dotenv():
+    """Load a .env file if python-dotenv is installed; silently skip if not."""
+    try:
+        from dotenv import load_dotenv as _load_dotenv
+
+        _load_dotenv()
+    except ImportError:
+        pass

--- a/src/utils/dotenv_loader.py
+++ b/src/utils/dotenv_loader.py
@@ -1,8 +1,0 @@
-def load_dotenv():
-    """Load a .env file if python-dotenv is installed; silently skip if not."""
-    try:
-        from dotenv import load_dotenv as _load_dotenv
-
-        _load_dotenv()
-    except ImportError:
-        pass

--- a/test/test_imap_backup.py
+++ b/test/test_imap_backup.py
@@ -33,6 +33,22 @@ def _mock_imap_env(port):
     }
 
 
+@pytest.fixture
+def dotenv_file(tmp_path):
+    """Create a .env file and run the test from its directory."""
+    original_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        def write(values):
+            (tmp_path / ".env").write_text(
+                "\n".join(f'{name}="{value}"' for name, value in values.items()), encoding="utf-8"
+            )
+
+        yield write
+    finally:
+        os.chdir(original_cwd)
+
+
 class TestBackupBasic:
     """Tests for basic backup functionality."""
 
@@ -74,6 +90,36 @@ class TestBackupBasic:
         inbox_path = tmp_path / "INBOX"
         eml_files = list(inbox_path.glob("*.eml"))
         assert len(eml_files) == 3
+
+    def test_backup_uses_dotenv_configuration(self, single_mock_server, tmp_path, dotenv_file):
+        """End-to-end: .env credentials and backup path produce a local backup."""
+        src_data = {"INBOX": [b"Subject: Dotenv\r\nMessage-ID: <dotenv@test>\r\n\r\nBody"]}
+        _, port = single_mock_server(src_data)
+        backup_path = tmp_path / "dotenv-backup"
+
+        dotenv_file({**_mock_imap_env(port), "BACKUP_LOCAL_PATH": str(backup_path)})
+        with temp_env({}), temp_argv(["backup_imap_emails.py"]):
+            backup_imap_emails.main()
+
+        assert len(list((backup_path / "INBOX").glob("*.eml"))) == 1
+
+    def test_backup_prefers_existing_os_environment(self, single_mock_server, tmp_path, dotenv_file):
+        """End-to-end: an OS value overrides the same value in .env."""
+        src_data = {"INBOX": [b"Subject: OS wins\r\nMessage-ID: <os@test>\r\n\r\nBody"]}
+        _, port = single_mock_server(src_data)
+        backup_path = tmp_path / "os-precedence-backup"
+
+        dotenv_file(
+            {
+                **_mock_imap_env(port),
+                "SRC_IMAP_HOST": "imap://localhost:1",
+                "BACKUP_LOCAL_PATH": str(backup_path),
+            }
+        )
+        with temp_env({"SRC_IMAP_HOST": f"imap://localhost:{port}"}), temp_argv(["backup_imap_emails.py"]):
+            backup_imap_emails.main()
+
+        assert len(list((backup_path / "INBOX").glob("*.eml"))) == 1
 
 
 class TestIncrementalBackup:

--- a/test/test_imap_compare.py
+++ b/test/test_imap_compare.py
@@ -33,6 +33,22 @@ def _mock_compare_env(src_port, dest_port):
     }
 
 
+@pytest.fixture
+def dotenv_file(tmp_path):
+    """Create a .env file and run the test from its directory."""
+    original_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        def write(values):
+            (tmp_path / ".env").write_text(
+                "\n".join(f'{name}="{value}"' for name, value in values.items()), encoding="utf-8"
+            )
+
+        yield write
+    finally:
+        os.chdir(original_cwd)
+
+
 class TestFolderComparison:
     """Tests for folder comparison functionality."""
 
@@ -70,6 +86,17 @@ class TestFolderComparison:
         # Source has 3, dest has 1
         assert "3" in captured.out
         assert "1" in captured.out
+
+    def test_compare_uses_dotenv_configuration(self, mock_server_factory, capsys, dotenv_file):
+        """End-to-end: .env credentials drive a successful account comparison."""
+        data = {"INBOX": [b"Subject: Dotenv\r\n\r\nBody"]}
+        _, _, src_port, dest_port = mock_server_factory(data, data.copy())
+
+        dotenv_file(_mock_compare_env(src_port, dest_port))
+        with temp_env({}), temp_argv(["compare_imap_folders.py"]):
+            compare_imap_folders.main()
+
+        assert "INBOX" in capsys.readouterr().out
 
     def test_folder_missing_on_destination(self, mock_server_factory, capsys):
         """Test when a folder exists on source but not destination."""

--- a/test/test_imap_count.py
+++ b/test/test_imap_count.py
@@ -29,6 +29,22 @@ def _mock_imap_env(port):
     }
 
 
+@pytest.fixture
+def dotenv_file(tmp_path):
+    """Create a .env file and run the test from its directory."""
+    original_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        def write(values):
+            (tmp_path / ".env").write_text(
+                "\n".join(f'{name}="{value}"' for name, value in values.items()), encoding="utf-8"
+            )
+
+        yield write
+    finally:
+        os.chdir(original_cwd)
+
+
 class TestEmailCounting:
     """Tests for email counting functionality."""
 
@@ -271,6 +287,16 @@ class TestMainFunction:
 
         captured = capsys.readouterr()
         assert "INBOX" in captured.out
+
+    def test_main_uses_dotenv_configuration(self, single_mock_server, capsys, dotenv_file):
+        """End-to-end: .env credentials drive IMAP counting."""
+        _, port = single_mock_server({"INBOX": [b"Subject: Dotenv\r\n\r\nBody"]})
+
+        dotenv_file(_mock_imap_env(port))
+        with temp_env({}), temp_argv(["count_imap_emails.py"]):
+            count_imap_emails.main()
+
+        assert "INBOX" in capsys.readouterr().out
 
     def test_missing_credentials(self, capsys):
         """Test that missing auth is rejected by argparse (neither password nor OAuth2 client-id)."""

--- a/test/test_imap_migrate.py
+++ b/test/test_imap_migrate.py
@@ -37,6 +37,22 @@ def _mock_migrate_env(src_port, dest_port):
     }
 
 
+@pytest.fixture
+def dotenv_file(tmp_path):
+    """Create a .env file and run the test from its directory."""
+    original_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        def write(values):
+            (tmp_path / ".env").write_text(
+                "\n".join(f'{name}="{value}"' for name, value in values.items()), encoding="utf-8"
+            )
+
+        yield write
+    finally:
+        os.chdir(original_cwd)
+
+
 class TestBasicMigration:
     """Tests for basic migration functionality."""
 
@@ -72,6 +88,17 @@ class TestBasicMigration:
             migrate_imap_emails.main()
 
         assert len(dest_server.folders["INBOX"]) == 3
+
+    def test_migration_uses_dotenv_configuration(self, mock_server_factory, dotenv_file):
+        """End-to-end: .env credentials migrate a message to the destination."""
+        src_data = {"INBOX": [b"Subject: Dotenv\r\nMessage-ID: <dotenv@test>\r\n\r\nBody"]}
+        _, dest_server, src_port, dest_port = mock_server_factory(src_data, {"INBOX": []})
+
+        dotenv_file(_mock_migrate_env(src_port, dest_port))
+        with temp_env({}), temp_argv(["migrate_imap_emails.py", "INBOX"]):
+            migrate_imap_emails.main()
+
+        assert len(dest_server.folders["INBOX"]) == 1
 
 
 class TestDuplicateHandling:

--- a/test/test_imap_restore.py
+++ b/test/test_imap_restore.py
@@ -33,6 +33,22 @@ def _mock_restore_env(port):
     }
 
 
+@pytest.fixture
+def dotenv_file(tmp_path):
+    """Create a .env file and run the test from its directory."""
+    original_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        def write(values):
+            (tmp_path / ".env").write_text(
+                "\n".join(f'{name}="{value}"' for name, value in values.items()), encoding="utf-8"
+            )
+
+        yield write
+    finally:
+        os.chdir(original_cwd)
+
+
 class TestLoadLabelsManifest:
     """Tests for loading labels manifest."""
 
@@ -257,6 +273,21 @@ Body content.
         env = _mock_restore_env(port)
         with temp_env(env), temp_argv(["restore_imap_emails.py", "--src-path", str(tmp_path), "INBOX"]):
             restore_imap_emails.main()
+
+    def test_restore_uses_dotenv_configuration(self, single_mock_server, tmp_path, dotenv_file):
+        """End-to-end: .env settings restore a local message to IMAP."""
+        inbox = tmp_path / "INBOX"
+        inbox.mkdir()
+        (inbox / "1_Dotenv.eml").write_bytes(
+            b"Subject: Dotenv\r\nMessage-ID: <dotenv@test>\r\n\r\nBody"
+        )
+        server, port = single_mock_server({"INBOX": []})
+
+        dotenv_file({**_mock_restore_env(port), "BACKUP_LOCAL_PATH": str(tmp_path)})
+        with temp_env({}), temp_argv(["restore_imap_emails.py", "INBOX"]):
+            restore_imap_emails.main()
+
+        assert len(server.folders["INBOX"]) == 1
 
     def test_restore_all_folders_scans_backup(self, single_mock_server, tmp_path):
         """End-to-end: restore all folders from a backup tree."""


### PR DESCRIPTION
## Add`.env` configuration support

### Summary

This PR adds optional `.env` configuration support to all primary IMAP CLI tools:

- `imap-backup`
- `imap-restore`
- `imap-migrate`
- `imap-count`
- `imap-compare`

### What changed

- Added `utils.dotenv` to load `.env` files from the current working directory or its parent directories.
- Added `python-dotenv` as an optional package extra: `imap-migration-tools[dotenv]`.
- Added a comprehensive `.env.example` covering account credentials, local paths, migration, backup, restore, comparison, and count settings.
- Updated README installation and configuration guidance, including pipx support.
- Documented configuration precedence:

  1. Command-line arguments
  2. Existing OS environment variables
  3. `.env` values
  4. Script defaults

- Added `AGENTS.md` with repository workflow, testing, style, and `.env` guidance.
- Updated CI to install `python-dotenv`.

### Testing

Added end-to-end `.env` coverage in each existing CLI test module:

- Backup verifies a `.env`-configured run writes local `.eml` files.
- Compare verifies `.env` source/destination settings connect to mock IMAP servers.
- Count verifies `.env` credentials drive IMAP counting.
- Migrate verifies `.env` settings copy messages between mock servers.
- Restore verifies `.env` settings upload local messages.
- Backup verifies an existing OS environment value overrides the corresponding `.env` value.

Also verified Ruff, whitespace checks, and the full test suite.