### PR TITLE
Fix Ruff formatting in `.env` integration tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,12 +41,14 @@ Tests use local mock IMAP servers and bind loopback ports. In restricted environ
 
 ## Verification before handoff
 
-Run the focused tests for changed code first, then the full suite when practical. Always run:
+Run the focused tests for changed code first, then the full suite when practical. Before every commit, always run:
 
 ```bash
 .venv/bin/python -m ruff check src/ tools/ test/
 .venv/bin/python -m ruff format --check src/ tools/ test/
 git diff --check
 ```
+
+If the formatter check reports files, run `ruff format` on those files, then rerun the complete check sequence. Do not rely on `ruff check` alone: it does not enforce the CI formatter check.
 
 For user-facing changes, verify the relevant README examples and the `.env.example` template match the implementation.

--- a/test/test_imap_backup.py
+++ b/test/test_imap_backup.py
@@ -39,6 +39,7 @@ def dotenv_file(tmp_path):
     original_cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
+
         def write(values):
             (tmp_path / ".env").write_text(
                 "\n".join(f'{name}="{value}"' for name, value in values.items()), encoding="utf-8"

--- a/test/test_imap_compare.py
+++ b/test/test_imap_compare.py
@@ -39,6 +39,7 @@ def dotenv_file(tmp_path):
     original_cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
+
         def write(values):
             (tmp_path / ".env").write_text(
                 "\n".join(f'{name}="{value}"' for name, value in values.items()), encoding="utf-8"

--- a/test/test_imap_count.py
+++ b/test/test_imap_count.py
@@ -35,6 +35,7 @@ def dotenv_file(tmp_path):
     original_cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
+
         def write(values):
             (tmp_path / ".env").write_text(
                 "\n".join(f'{name}="{value}"' for name, value in values.items()), encoding="utf-8"

--- a/test/test_imap_migrate.py
+++ b/test/test_imap_migrate.py
@@ -43,6 +43,7 @@ def dotenv_file(tmp_path):
     original_cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
+
         def write(values):
             (tmp_path / ".env").write_text(
                 "\n".join(f'{name}="{value}"' for name, value in values.items()), encoding="utf-8"

--- a/test/test_imap_restore.py
+++ b/test/test_imap_restore.py
@@ -39,6 +39,7 @@ def dotenv_file(tmp_path):
     original_cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
+
         def write(values):
             (tmp_path / ".env").write_text(
                 "\n".join(f'{name}="{value}"' for name, value in values.items()), encoding="utf-8"
@@ -278,9 +279,7 @@ Body content.
         """End-to-end: .env settings restore a local message to IMAP."""
         inbox = tmp_path / "INBOX"
         inbox.mkdir()
-        (inbox / "1_Dotenv.eml").write_bytes(
-            b"Subject: Dotenv\r\nMessage-ID: <dotenv@test>\r\n\r\nBody"
-        )
+        (inbox / "1_Dotenv.eml").write_bytes(b"Subject: Dotenv\r\nMessage-ID: <dotenv@test>\r\n\r\nBody")
         server, port = single_mock_server({"INBOX": []})
 
         dotenv_file({**_mock_restore_env(port), "BACKUP_LOCAL_PATH": str(tmp_path)})


### PR DESCRIPTION
## Fix Ruff formatting in `.env` integration tests

### Summary

Fixes CI formatting failures introduced by the `.env` configuration support tests.

### Changes

- Reformats the affected test modules with Ruff:
  - `test_imap_backup.py`
  - `test_imap_compare.py`
  - `test_imap_count.py`
  - `test_imap_migrate.py`
  - `test_imap_restore.py`
- Updates `AGENTS.md` to require both lint and formatter checks before committing.
- Documents that `ruff check` alone does not enforce the CI formatter check, and requires rerunning the full verification sequence after formatting changes.