### PR TITLE
Fix destination IMAP namespace handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ SRC_IMAP_PASSWORD="your-app-password"
 DEST_IMAP_HOST="imap.destination.com"
 DEST_IMAP_USERNAME="dest@domain.com"
 DEST_IMAP_PASSWORD="dest-app-password"
+DEST_FOLDER_PREFIX=""  # Optional override; normally detected through IMAP NAMESPACE
+DEST_FOLDER_SEP=""     # Optional override, e.g. "." for INBOX.-prefixed servers
 
 # OAuth2 (optional; use instead of the corresponding password)
 SRC_OAUTH2_CLIENT_ID="your-client-id"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,8 @@ Tests use local mock IMAP servers and bind loopback ports. In restricted environ
 
 ## Verification before handoff
 
+Do not stage or commit changes automatically. Only create a commit when the user explicitly asks for one.
+
 Run the focused tests for changed code first, then the full suite when practical. Before every commit, always run:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -221,6 +221,11 @@ Configuration values are applied in this order, with earlier entries taking prec
 3. Values in `.env`
 4. Script defaults
 
+Destination namespace prefixes are detected automatically through the IMAP
+`NAMESPACE` command. If a server does not advertise its namespace correctly,
+set `DEST_FOLDER_PREFIX` and `DEST_FOLDER_SEP` explicitly (for example,
+`INBOX.` and `.` for a typical cPanel/Dovecot configuration).
+
 
 ### Method 3: Command Line Arguments (Overrides)
 All scripts support command-line arguments which take precedence over environment variables.

--- a/src/imap_compare.py
+++ b/src/imap_compare.py
@@ -258,6 +258,13 @@ def main():
             dest = imap_common.get_imap_connection(args.dest_host, args.dest_user, args.dest_pass, dest_oauth2_token)
             if not dest:
                 return
+            detected_prefix, detected_sep = imap_common.detect_dest_namespace(dest)
+            dest_prefix = os.getenv("DEST_FOLDER_PREFIX")
+            dest_sep = os.getenv("DEST_FOLDER_SEP")
+            dest.configure_folder_mapping(
+                dest_prefix or detected_prefix,
+                dest_sep or detected_sep,
+            )
 
         # List Source Folders
         print("Listing folders in Source...")

--- a/src/imap_migrate.py
+++ b/src/imap_migrate.py
@@ -1001,6 +1001,18 @@ def main():
         if not dest_main:
             sys.exit(1)
 
+        detected_prefix, detected_sep = imap_common.detect_dest_namespace(dest_main)
+        dest_prefix = os.getenv("DEST_FOLDER_PREFIX")
+        dest_sep = os.getenv("DEST_FOLDER_SEP")
+        dest_conf["folder_prefix"] = dest_prefix or detected_prefix
+        dest_conf["folder_sep"] = dest_sep or detected_sep
+        dest_main.configure_folder_mapping(dest_conf["folder_prefix"], dest_conf["folder_sep"])
+        if dest_conf["folder_prefix"]:
+            safe_print(
+                f"Destination namespace detected: prefix '{dest_conf['folder_prefix']}', "
+                f"separator '{dest_conf['folder_sep']}'"
+            )
+
         label_index = None
         if gmail_mode and preserve_labels:
             safe_print("Gmail mode enabled: building label index from source...")

--- a/src/utils/imap_common.py
+++ b/src/utils/imap_common.py
@@ -275,7 +275,41 @@ def get_imap_connection_from_conf(conf):
             "oauth2": dict or None  # Contains provider, client_id, email, client_secret
         }
     """
-    return get_imap_connection(conf["host"], conf["user"], conf.get("password"), conf.get("oauth2_token"))
+    conn = get_imap_connection(conf["host"], conf["user"], conf.get("password"), conf.get("oauth2_token"))
+    if conn and hasattr(conn, "configure_folder_mapping"):
+        conn.configure_folder_mapping(conf.get("folder_prefix", ""), conf.get("folder_sep", "/"))
+    return conn
+
+
+def detect_dest_namespace(imap_conn):
+    """Return the destination personal namespace prefix and separator.
+
+    Servers without RFC 2342 NAMESPACE support use the conventional empty
+    prefix and slash separator.
+    """
+    try:
+        typ, data = imap_conn.namespace()
+        if typ != "OK" or not data or not data[0]:
+            return "", "/"
+
+        response = data[0].decode("utf-8", errors="replace") if isinstance(data[0], bytes) else str(data[0])
+        match = re.match(
+            r'^\s*\(\s*\(\s*"(?P<prefix>(?:\\.|[^"])*)"\s+'
+            r'(?:(?:"(?P<sep>(?:\\.|[^"])*)")|NIL)',
+            response,
+            re.IGNORECASE,
+        )
+        if not match:
+            return "", "/"
+
+        def unescape(value):
+            return re.sub(r"\\(.)", r"\1", value) if value is not None else None
+
+        prefix = unescape(match.group("prefix")) or ""
+        separator = unescape(match.group("sep")) or "/"
+        return prefix, separator
+    except Exception:
+        return "", "/"
 
 
 def get_imap_connection(host, user, password=None, oauth2_token=None):

--- a/src/utils/imap_retry.py
+++ b/src/utils/imap_retry.py
@@ -36,7 +36,20 @@ class ConnectionProxy:
         }
     )
 
-    def __init__(self, conn, max_retries=3, initial_wait=5, log_fn=print):
+    FOLDER_ARG_INDEXES = {
+        "append": (0,),
+        "copy": (1,),
+        "create": (0,),
+        "delete": (0,),
+        "examine": (0,),
+        "rename": (0, 1),
+        "select": (0,),
+        "status": (0,),
+        "subscribe": (0,),
+        "unsubscribe": (0,),
+    }
+
+    def __init__(self, conn, max_retries=3, initial_wait=5, log_fn=print, folder_prefix="", folder_sep="/"):
         if max_retries < 1:
             raise ValueError(f"max_retries must be >= 1, got {max_retries}")
         if initial_wait < 0:
@@ -45,6 +58,45 @@ class ConnectionProxy:
         self._max_retries = max_retries
         self._initial_wait = initial_wait
         self._log_fn = log_fn
+        self.configure_folder_mapping(folder_prefix, folder_sep)
+
+    def configure_folder_mapping(self, folder_prefix="", folder_sep="/"):
+        """Configure destination mailbox prefix and hierarchy separator mapping."""
+        self._folder_prefix = folder_prefix or ""
+        self._folder_sep = folder_sep or "/"
+
+    def _map_folder(self, folder):
+        if not isinstance(folder, (str, bytes)):
+            return folder
+
+        was_bytes = isinstance(folder, bytes)
+        value = folder.decode("utf-8") if was_bytes else folder
+        quoted = len(value) >= 2 and value.startswith('"') and value.endswith('"')
+        name = value[1:-1] if quoted else value
+
+        if name.upper() != "INBOX" and not (self._folder_prefix and name.startswith(self._folder_prefix)):
+            if self._folder_sep != "/":
+                name = name.replace("/", self._folder_sep)
+            name = f"{self._folder_prefix}{name}"
+
+        mapped = f'"{name}"' if quoted else name
+        return mapped.encode("utf-8") if was_bytes else mapped
+
+    def _map_folder_args(self, name, args):
+        indexes = self.FOLDER_ARG_INDEXES.get(name, ())
+        uid_command = (
+            args[0].decode("ascii", errors="ignore") if args and isinstance(args[0], bytes) else args[0] if args else ""
+        )
+        if name == "uid" and str(uid_command).lower() == "copy":
+            indexes = (2,)
+        if not indexes:
+            return args
+
+        mapped = list(args)
+        for index in indexes:
+            if index < len(mapped) and mapped[index] is not None:
+                mapped[index] = self._map_folder(mapped[index])
+        return tuple(mapped)
 
     @classmethod
     def _is_transient_error(cls, data):
@@ -58,10 +110,14 @@ class ConnectionProxy:
 
     def __getattr__(self, name):
         attr = getattr(self._conn, name)
-        if name not in self.RETRYABLE_METHODS or not callable(attr):
+        maps_folders = name in self.FOLDER_ARG_INDEXES or name == "uid"
+        if (name not in self.RETRYABLE_METHODS and not maps_folders) or not callable(attr):
             return attr
 
         def wrapper(*args, **kwargs):
+            args = self._map_folder_args(name, args)
+            if name not in self.RETRYABLE_METHODS:
+                return attr(*args, **kwargs)
             last_result = None
             for attempt in range(self._max_retries):
                 result = attr(*args, **kwargs)

--- a/test/test_imap_compare.py
+++ b/test/test_imap_compare.py
@@ -119,6 +119,22 @@ class TestFolderComparison:
         assert "Archive" in captured.out
         assert "N/A" in captured.out
 
+    def test_destination_namespace_prefix_is_used(self, mock_server_factory, capsys):
+        """Comparison selects the destination's mapped mailbox name."""
+        src_data = {"INBOX": [], "Sent": [b"Subject: Sent\r\n\r\nBody"]}
+        dest_data = {"INBOX": [], "INBOX.Sent": [b"Subject: Sent\r\n\r\nBody"]}
+        _, dest_server, p1, p2 = mock_server_factory(src_data, dest_data)
+        dest_server.namespace_prefix = "INBOX."
+        dest_server.namespace_separator = "."
+
+        env = _mock_compare_env(p1, p2)
+        with temp_env(env), temp_argv(["compare_imap_folders.py"]):
+            compare_imap_folders.main()
+
+        sent_row = next(line for line in capsys.readouterr().out.splitlines() if line.startswith("Sent"))
+        assert "N/A" not in sent_row
+        assert sent_row.count("1") == 2
+
 
 class TestEmptyFolders:
     """Tests for empty folder handling."""

--- a/test/test_imap_migrate.py
+++ b/test/test_imap_migrate.py
@@ -207,6 +207,45 @@ class TestFolderHandling:
         assert "Sent" in dest_server.folders
         assert "Drafts" in dest_server.folders
 
+    def test_destination_namespace_prefix_is_detected_and_applied(self, mock_server_factory):
+        """Destination personal namespaces are applied to non-INBOX folders."""
+        message = b"Subject: Namespaced\r\nMessage-ID: <namespace@test>\r\n\r\nBody"
+        src_data = {"INBOX": [], "Parent/Child": [message]}
+        dest_data = {"INBOX": []}
+
+        _, dest_server, p1, p2 = mock_server_factory(src_data, dest_data)
+        dest_server.namespace_prefix = "INBOX."
+        dest_server.namespace_separator = "."
+
+        env = _mock_migrate_env(p1, p2)
+        with temp_env(env), temp_argv(["migrate_imap_emails.py"]):
+            migrate_imap_emails.main()
+
+        assert "Parent/Child" not in dest_server.folders
+        assert "INBOX.Parent.Child" in dest_server.folders
+        assert len(dest_server.folders["INBOX.Parent.Child"]) == 1
+
+    def test_destination_namespace_can_be_configured_explicitly(self, mock_server_factory):
+        """Environment overrides support servers without NAMESPACE."""
+        message = b"Subject: Override\r\nMessage-ID: <override@test>\r\n\r\nBody"
+        src_data = {"INBOX": [], "Sent": [message]}
+        dest_data = {"INBOX": []}
+
+        _, dest_server, p1, p2 = mock_server_factory(src_data, dest_data)
+        dest_server.namespace_prefix = "INBOX."
+        dest_server.namespace_separator = "."
+        dest_server.namespace_supported = False
+
+        env = {
+            **_mock_migrate_env(p1, p2),
+            "DEST_FOLDER_PREFIX": "INBOX.",
+            "DEST_FOLDER_SEP": ".",
+        }
+        with temp_env(env), temp_argv(["migrate_imap_emails.py"]):
+            migrate_imap_emails.main()
+
+        assert len(dest_server.folders["INBOX.Sent"]) == 1
+
     def test_empty_folder_handling(self, mock_server_factory):
         """Test that empty folders are handled gracefully."""
         src_data = {"INBOX": [], "Empty": []}

--- a/test/test_imap_retry.py
+++ b/test/test_imap_retry.py
@@ -222,3 +222,12 @@ class TestConnectionProxy:
         proxy.select('"Parent/Child"')
 
         conn.select.assert_called_once_with('"Parent/Child"')
+
+    def test_mapping_preserves_non_string_values_and_forwards_status(self):
+        conn = Mock()
+        conn.status.return_value = ("OK", [b'"INBOX.Sent" (MESSAGES 1)'])
+        proxy = imap_retry.ConnectionProxy(conn, folder_prefix="INBOX.", folder_sep=".")
+
+        assert proxy._map_folder(None) is None
+        assert proxy.status('"Sent"', "(MESSAGES)") == ("OK", [b'"INBOX.Sent" (MESSAGES 1)'])
+        conn.status.assert_called_once_with('"INBOX.Sent"', "(MESSAGES)")

--- a/test/test_imap_retry.py
+++ b/test/test_imap_retry.py
@@ -12,6 +12,7 @@ Tests cover:
 import imaplib
 import os
 import sys
+from unittest.mock import Mock, call
 
 import pytest
 
@@ -186,3 +187,38 @@ class TestConnectionProxy:
     def test_initial_wait_negative_raises(self):
         with pytest.raises(ValueError, match="initial_wait must be >= 0"):
             imap_retry.ConnectionProxy(None, initial_wait=-1)
+
+    def test_destination_namespace_maps_mailbox_commands(self):
+        conn = Mock()
+        conn.create.return_value = ("OK", [b""])
+        conn.select.return_value = ("OK", [b""])
+        conn.append.return_value = ("OK", [b""])
+        proxy = imap_retry.ConnectionProxy(conn, folder_prefix="INBOX.", folder_sep=".")
+
+        proxy.create('"Parent/Child"')
+        proxy.select('"Parent/Child"')
+        proxy.append('"Parent/Child"', None, None, b"message")
+
+        assert conn.create.call_args_list == [call('"INBOX.Parent.Child"')]
+        assert conn.select.call_args_list == [call('"INBOX.Parent.Child"')]
+        assert conn.append.call_args_list == [call('"INBOX.Parent.Child"', None, None, b"message")]
+
+    def test_destination_namespace_does_not_rewrite_inbox_or_existing_prefix(self):
+        conn = Mock()
+        conn.select.return_value = ("OK", [b""])
+        proxy = imap_retry.ConnectionProxy(conn)
+        proxy.configure_folder_mapping("INBOX.", ".")
+
+        proxy.select('"INBOX"')
+        proxy.select('"INBOX.Sent"')
+
+        assert conn.select.call_args_list == [call('"INBOX"'), call('"INBOX.Sent"')]
+
+    def test_default_proxy_does_not_rewrite_mailboxes(self):
+        conn = Mock()
+        conn.select.return_value = ("OK", [b""])
+        proxy = imap_retry.ConnectionProxy(conn)
+
+        proxy.select('"Parent/Child"')
+
+        conn.select.assert_called_once_with('"Parent/Child"')

--- a/test/utils/test_imap_common.py
+++ b/test/utils/test_imap_common.py
@@ -118,13 +118,47 @@ class TestGetImapConnection:
         captured = capsys.readouterr()
         assert "Invalid IMAP host" in captured.out
 
-        # No scheme (urllib fails to parse scheme if missing :// or just host)
-        # But our code checks "://" in host. If not, it assumes basic host.
-        # So we test a case where "://" is present but scheme is empty?
-        # "://hostname" parses scheme as empty string.
+        # A malformed URL with an empty scheme is also invalid.
         imap_common.get_imap_connection("://mail.example.com", "user", "pass")
         captured = capsys.readouterr()
         assert "Invalid IMAP host" in captured.out
+
+
+class TestDetectDestinationNamespace:
+    @pytest.mark.parametrize(
+        ("response", "expected"),
+        [
+            ([b'(("INBOX." ".")) NIL NIL'], ("INBOX.", ".")),
+            ([b'(("" "/")) NIL NIL'], ("", "/")),
+            ([b'(("INBOX/" "/")) (("Other Users/" "/")) NIL'], ("INBOX/", "/")),
+            ([b'NIL (("Other Users/" "/")) (("Shared/" "/"))'], ("", "/")),
+        ],
+    )
+    def test_parses_personal_namespace(self, response, expected):
+        conn = Mock()
+        conn.namespace.return_value = ("OK", response)
+
+        assert imap_common.detect_dest_namespace(conn) == expected
+
+    @pytest.mark.parametrize(
+        "result",
+        [
+            ("BAD", [b"NAMESPACE not supported"]),
+            ("OK", []),
+            ("OK", [b"not a namespace response"]),
+        ],
+    )
+    def test_falls_back_when_namespace_is_unavailable(self, result):
+        conn = Mock()
+        conn.namespace.return_value = result
+
+        assert imap_common.detect_dest_namespace(conn) == ("", "/")
+
+    def test_falls_back_when_namespace_command_raises(self):
+        conn = Mock()
+        conn.namespace.side_effect = RuntimeError("unsupported")
+
+        assert imap_common.detect_dest_namespace(conn) == ("", "/")
 
 
 class TestNormalizeFolderName:

--- a/tools/mock_imap_server.py
+++ b/tools/mock_imap_server.py
@@ -60,6 +60,15 @@ class MockIMAPHandler(socketserver.StreamRequestHandler):
                 if cmd == "LOGIN":
                     self.send_response(tag, "OK LOGIN completed")
 
+                elif cmd == "NAMESPACE":
+                    prefix = getattr(self.server, "namespace_prefix", None)
+                    separator = getattr(self.server, "namespace_separator", "/")
+                    if prefix is None or not getattr(self.server, "namespace_supported", True):
+                        self.send_response(tag, "BAD NAMESPACE not supported")
+                    else:
+                        self.wfile.write(f'* NAMESPACE (("{prefix}" "{separator}")) NIL NIL\r\n'.encode())
+                        self.send_response(tag, "OK NAMESPACE completed")
+
                 elif cmd == "APPEND":
                     # Check for literal size
                     import re
@@ -84,6 +93,15 @@ class MockIMAPHandler(socketserver.StreamRequestHandler):
                             mailbox = clean_args[1:end_quote]
                     else:
                         mailbox = clean_args.split(" ")[0]
+
+                    prefix = getattr(self.server, "namespace_prefix", None)
+                    if prefix and mailbox.upper() != "INBOX" and not mailbox.startswith(prefix):
+                        self.send_response(
+                            tag,
+                            "NO Client tried to access nonexistent namespace. "
+                            f"(Mailbox name should probably be prefixed with: {prefix})",
+                        )
+                        continue
 
                     if mailbox not in self.current_folders:
                         self.current_folders[mailbox] = []
@@ -131,6 +149,15 @@ class MockIMAPHandler(socketserver.StreamRequestHandler):
                 elif cmd == "SELECT":
                     folder = args.strip().strip('"')
 
+                    prefix = getattr(self.server, "namespace_prefix", None)
+                    if prefix and folder.upper() != "INBOX" and not folder.startswith(prefix):
+                        self.send_response(
+                            tag,
+                            "NO Client tried to access nonexistent namespace. "
+                            f"(Mailbox name should probably be prefixed with: {prefix})",
+                        )
+                        continue
+
                     # For retry testing: if folder starts with NO, fail immediately
                     if folder.startswith("NO"):
                         # e.g. "NO [UNAVAILABLE]"
@@ -174,6 +201,14 @@ class MockIMAPHandler(socketserver.StreamRequestHandler):
 
                 elif cmd == "CREATE":
                     folder = args.strip().strip('"')
+                    prefix = getattr(self.server, "namespace_prefix", None)
+                    if prefix and folder.upper() != "INBOX" and not folder.startswith(prefix):
+                        self.send_response(
+                            tag,
+                            "NO Client tried to access nonexistent namespace. "
+                            f"(Mailbox name should probably be prefixed with: {prefix})",
+                        )
+                        continue
                     if folder not in self.current_folders:
                         self.current_folders[folder] = []
                     self.send_response(tag, "OK CREATE completed")


### PR DESCRIPTION
## Summary

This pull request fixes migrations and comparisons against destination IMAP servers that require personal folders to use a namespace prefix, such as the common cPanel/Dovecot convention:

```text
INBOX.Sent
INBOX.Archive
INBOX.Parent.Child
```

Previously, the tools sent source folder names directly to the destination without accounting for the destination server’s namespace or hierarchy separator. This caused every non-INBOX folder to be skipped or fail on namespace-prefixed servers.

Closes #45.

## Original problem

During a normal migration, `imap_migrate.py` used the source folder name for destination operations:

```python
dest.create(f'"{folder_name}"')
dest.select(f'"{folder_name}"')
```

For a source folder named `Sent`, the destination therefore received:

```imap
CREATE "Sent"
SELECT "Sent"
```

However, cPanel and some Dovecot configurations expose personal mailboxes beneath an `INBOX.` namespace and require:

```imap
CREATE "INBOX.Sent"
SELECT "INBOX.Sent"
```

The server rejected the unqualified folder name with an error similar to:

```text
Client tried to access nonexistent namespace.
(Mailbox name should probably be prefixed with: INBOX.)
```

The folder creation failure could be hidden because creation is intentionally best-effort. Selection or subsequent operations would then fail, causing the folder to be skipped or its messages to fail during append.

`INBOX` itself remained unaffected, which made the problem particularly easy to overlook: the migration could appear to complete while Sent, Drafts, Archive, and other folders were missing.

Nested folders presented an additional compatibility problem. A source folder such as:

```text
Parent/Child
```

may need to be addressed on the destination as:

```text
INBOX.Parent.Child
```

This requires both adding the destination namespace prefix and translating the hierarchy separator.

The same folder-addressing problem also affected `imap_compare.py`, which attempted to select destination folders using the original source names and could incorrectly report them as missing.

## Why existing tests did not catch it

The project’s mock IMAP server previously accepted any mailbox name supplied to `CREATE` and `APPEND`. It did not:

- advertise an RFC 2342 personal namespace;
- require a namespace prefix;
- reject bare non-INBOX mailbox names; or
- model a destination hierarchy separator different from `/`.

As a result, existing folder migration tests succeeded with bare names such as `Sent` and `Archive`, even though those names would be rejected by an affected real-world destination.

## Solution

### RFC 2342 namespace detection

A new `detect_dest_namespace()` helper queries the destination using the IMAP `NAMESPACE` command and extracts the first personal namespace prefix and hierarchy separator.

For example, this response:

```text
(("INBOX." ".")) NIL NIL
```

produces:

```python
("INBOX.", ".")
```

The parser handles:

- namespace-prefixed personal mailboxes;
- modern servers with an empty personal prefix;
- responses containing other-user and shared namespaces;
- unsupported `NAMESPACE` commands;
- empty or malformed responses; and
- exceptions raised while querying the server.

When namespace discovery is unavailable or cannot be parsed, behavior falls back to the conventional empty prefix and `/` separator, preserving compatibility with existing servers.

### Transparent destination mailbox mapping

`ConnectionProxy` now supports optional destination folder mapping through:

```python
ConnectionProxy(
    connection,
    folder_prefix="INBOX.",
    folder_sep=".",
)
```

Mapping can also be applied to an already-open connection:

```python
connection.configure_folder_mapping("INBOX.", ".")
```

This is needed because the destination namespace can only be discovered after connecting and authenticating.

The proxy transparently rewrites mailbox arguments for folder-sensitive IMAP operations, including:

- `APPEND`
- `COPY`, including `UID COPY`
- `CREATE`
- `DELETE`
- `EXAMINE`
- `RENAME`
- `SELECT`
- `STATUS`
- `SUBSCRIBE`
- `UNSUBSCRIBE`

Examples:

```text
Sent                 → INBOX.Sent
Parent/Child         → INBOX.Parent.Child
"Parent/Child"       → "INBOX.Parent.Child"
```

The mapping deliberately:

- leaves `INBOX` unchanged;
- avoids adding the prefix to an already-prefixed folder;
- preserves quoted mailbox arguments;
- supports string and byte mailbox values; and
- remains a no-op under the default empty-prefix, slash-separator configuration.

### Worker and reconnection propagation

Migration appends happen through worker-thread IMAP connections rather than exclusively through the initial destination connection.

The detected mapping is therefore stored in `dest_conf`:

```python
dest_conf["folder_prefix"]
dest_conf["folder_sep"]
```

`get_imap_connection_from_conf()` applies those values whenever it creates a connection. This ensures the same mapping is used by:

- the initial destination connection;
- worker-thread connections;
- replacement connections after a disconnect; and
- OAuth2 reconnections.

Without this propagation, initial folder creation could succeed while worker-thread appends still used bare source folder names.

### Comparison support

`imap_compare.py` now performs the same namespace detection and configures its destination connection before counting messages.

This allows a source folder named `Sent` to be compared with `INBOX.Sent` on a namespace-prefixed destination instead of incorrectly displaying `N/A`.

### Manual configuration overrides

Some servers require a namespace prefix but do not implement `NAMESPACE`, or advertise incomplete namespace information.

The following environment variables can override automatic detection:

```dotenv
DEST_FOLDER_PREFIX="INBOX."
DEST_FOLDER_SEP="."
```

Non-empty explicit values take precedence over detected values.

These options are documented in both `README.md` and `.env.example`.

## Mock server improvements

The test IMAP server can now:

- respond to the `NAMESPACE` command;
- advertise a configurable personal prefix and separator;
- simulate a server without `NAMESPACE` support; and
- reject unprefixed non-INBOX `CREATE`, `SELECT`, and `APPEND` commands with the same class of error reported by cPanel/Dovecot.

This provides a faithful end-to-end reproduction rather than testing only the mapping helper in isolation.

## Test coverage

New unit tests cover namespace parsing for:

- `INBOX.` with a dot separator;
- empty personal prefixes;
- slash-prefixed namespaces;
- responses containing other-user and shared namespaces;
- unsupported `NAMESPACE`;
- empty responses;
- malformed responses; and
- command exceptions.

Connection mapping tests verify:

- prefix application;
- hierarchy-separator translation;
- mapping of create, select, and append operations;
- preservation of `INBOX`;
- prevention of duplicate prefixes;
- post-construction configuration; and
- unchanged default behavior.

End-to-end tests verify:

- automatic namespace detection during migration;
- migration of a nested source folder to its correctly prefixed destination name;
- successful message append through worker-thread connections;
- absence of the incorrect bare destination folder;
- explicit environment overrides when `NAMESPACE` is unavailable; and
- namespace-aware destination folder comparison.

## Example behavior

Given:

```text
Source folder: Parent/Child
Destination namespace: (("INBOX." "."))
```

Before this change:

```imap
CREATE "Parent/Child"
SELECT "Parent/Child"
APPEND "Parent/Child" ...
```

Result:

```text
NO Client tried to access nonexistent namespace.
```

After this change:

```imap
CREATE "INBOX.Parent.Child"
SELECT "INBOX.Parent.Child"
APPEND "INBOX.Parent.Child" ...
```

Result: the folder is created and its messages are migrated successfully.

## Backward compatibility

Servers using conventional, unprefixed mailbox names retain the existing behavior:

```text
Sent         → Sent
Parent/Child → Parent/Child
INBOX        → INBOX
```

No existing command-line options or environment variables were removed or changed.

Compatibility wrappers continue to use the updated primary entry points.

## Documentation and contributor guidance

This pull request updates:

- `.env.example` with the optional namespace override variables;
- `README.md` with automatic detection and override instructions; and
- `AGENTS.md` to state that agents must not stage or commit changes unless explicitly asked by the user.

## Verification

The complete project test suite passes:

```text
440 passed
```

The required repository checks also pass:

```text
.venv/bin/python -m ruff check src/ tools/ test/
.venv/bin/python -m ruff format --check src/ tools/ test/
git diff --check
```

Results:

```text
All checks passed
44 files already formatted
No whitespace errors
```