### PR TITLE
Improve Microsoft OAuth account type handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,11 @@ IMAP_USERNAME=""
 IMAP_PASSWORD=""
 OAUTH2_CLIENT_ID=""
 OAUTH2_CLIENT_SECRET=""
+ACCOUNT_TYPE="auto"  # OAuth provider account type: auto, personal, or work (imap-count)
+
+# Microsoft account type overrides for dual-account scripts
+SRC_ACCOUNT_TYPE="auto"
+DEST_ACCOUNT_TYPE="auto"
 
 # Shared options
 MAX_WORKERS=4       # Number of parallel threads

--- a/README.md
+++ b/README.md
@@ -763,6 +763,39 @@ python3 imap_migrate.py \
 
 The script will print a device code and URL. Open the URL in a browser, enter the code, and sign in to authorize access.
 
+#### Personal and work Microsoft accounts
+
+Microsoft account type is detected automatically for common Hotmail, Outlook,
+Live, and MSN domains. If the email address does not identify the account type
+correctly, select it explicitly without needing to know Microsoft's tenant
+names:
+
+```bash
+# Single-account command
+python3 imap_count.py \
+  --host "outlook.office365.com" \
+  --user "user@example.com" \
+  --oauth2-client-id "your-application-client-id" \
+  --account-type personal
+
+# Dual-account command
+python3 imap_migrate.py \
+  --src-host "outlook.office365.com" \
+  --src-user "user@example.com" \
+  --src-oauth2-client-id "your-application-client-id" \
+  --src-account-type personal \
+  --dest-host "imap.other.com" \
+  --dest-user "user@other.com" \
+  --dest-pass "password"
+```
+
+Accepted values are `auto` (default), `personal`, and `work`. Environment
+equivalents are `ACCOUNT_TYPE` for `imap_count.py`, and
+`SRC_ACCOUNT_TYPE` / `DEST_ACCOUNT_TYPE` for dual-account
+commands. `personal` supports Microsoft accounts registered with any email
+domain; `work` forces the existing organizational tenant discovery even for a
+normally personal domain such as `hotmail.com`.
+
 ### Google (Gmail)
 
 Requires the `google-auth-oauthlib` package (`pip install google-auth-oauthlib`). Uses the **installed app flow** — opens a browser window for consent. Both `--oauth2-client-id` and `--oauth2-client-secret` are required.

--- a/src/auth/imap_oauth2.py
+++ b/src/auth/imap_oauth2.py
@@ -71,12 +71,12 @@ def discover_microsoft_tenant(email):
     return oauth2_microsoft.discover_tenant(email)
 
 
-def acquire_microsoft_oauth2_token(client_id, email):
+def acquire_microsoft_oauth2_token(client_id, email, account_type="auto"):
     """
     Acquires a Microsoft OAuth2 access token using the MSAL device code flow.
     Delegates to oauth2_microsoft module.
     """
-    return oauth2_microsoft.acquire_token(client_id, email)
+    return oauth2_microsoft.acquire_token(client_id, email, account_type)
 
 
 def acquire_google_oauth2_token(client_id, client_secret):
@@ -87,7 +87,7 @@ def acquire_google_oauth2_token(client_id, client_secret):
     return oauth2_google.acquire_token(client_id, client_secret)
 
 
-def acquire_oauth2_token_for_provider(provider, client_id, email, client_secret=None):
+def acquire_oauth2_token_for_provider(provider, client_id, email, client_secret=None, account_type="auto"):
     """
     Acquires an OAuth2 token for the specified provider.
 
@@ -98,7 +98,7 @@ def acquire_oauth2_token_for_provider(provider, client_id, email, client_secret=
         client_secret: Required for Google, not needed for Microsoft
     """
     if provider == "microsoft":
-        return oauth2_microsoft.acquire_token(client_id, email)
+        return oauth2_microsoft.acquire_token(client_id, email, account_type)
     elif provider == "google":
         if not client_secret:
             print(
@@ -113,7 +113,7 @@ def acquire_oauth2_token_for_provider(provider, client_id, email, client_secret=
         return None
 
 
-def acquire_token(host, client_id, email, client_secret=None, label=None):
+def acquire_token(host, client_id, email, client_secret=None, label=None, account_type="auto"):
     """
     Detect the OAuth2 provider from the host and acquire a token.
 
@@ -137,7 +137,7 @@ def acquire_token(host, client_id, email, client_secret=None, label=None):
         print(f"Acquiring OAuth2 token for {label} ({provider})...")
     else:
         print(f"Acquiring OAuth2 token ({provider})...")
-    token = acquire_oauth2_token_for_provider(provider, client_id, email, client_secret)
+    token = acquire_oauth2_token_for_provider(provider, client_id, email, client_secret, account_type=account_type)
     if not token:
         if label:
             print(f"Error: Failed to acquire OAuth2 token for {label}.")
@@ -194,7 +194,11 @@ def refresh_oauth2_token(conf, old_token):
             return conf["oauth2_token"]
 
         new_token = acquire_oauth2_token_for_provider(
-            oauth2["provider"], oauth2["client_id"], oauth2["email"], oauth2.get("client_secret")
+            oauth2["provider"],
+            oauth2["client_id"],
+            oauth2["email"],
+            oauth2.get("client_secret"),
+            account_type=oauth2.get("account_type", "auto"),
         )
         if new_token:
             conf["oauth2_token"] = new_token

--- a/src/auth/oauth2_microsoft.py
+++ b/src/auth/oauth2_microsoft.py
@@ -75,6 +75,16 @@ def discover_tenant(email):
     if domain in _tenant_cache:
         return _tenant_cache[domain]
 
+    # Personal Microsoft accounts (live.com identity provider) live in the
+    # "consumers" tenant. Auto-discovery via login.microsoftonline.com for
+    # these domains returns a Microsoft-internal work/school tenant that
+    # rejects personal accounts with AADSTS50020. Short-circuit here.
+    if domain in ("hotmail.com", "outlook.com", "live.com", "msn.com",
+                  "hotmail.co.uk", "outlook.co.uk", "live.co.uk",
+                  "hotmail.fr", "outlook.fr", "hotmail.de", "outlook.de"):
+        _tenant_cache[domain] = "consumers"
+        return "consumers"
+
     domain_quoted = urllib.parse.quote(domain, safe=".-")
     path = f"/{domain_quoted}/.well-known/openid-configuration"
 
@@ -120,7 +130,10 @@ def acquire_token(client_id, email):
         authority = f"{authority_base.rstrip('/')}/{tenant_id}"
     else:
         authority = f"https://login.microsoftonline.com/{tenant_id}"
-    scopes = ["https://outlook.office365.com/IMAP.AccessAsUser.All"]
+    # Personal accounts (consumers tenant) require the outlook.office.com
+    # resource URL, not outlook.office365.com, or AADSTS70011 fires.
+    resource_host = "outlook.office.com" if tenant_id == "consumers" else "outlook.office365.com"
+    scopes = [f"https://{resource_host}/IMAP.AccessAsUser.All"]
 
     # Reuse cached MSAL app so acquire_token_silent can access refresh tokens
     cache_key = (client_id, tenant_id)

--- a/src/auth/oauth2_microsoft.py
+++ b/src/auth/oauth2_microsoft.py
@@ -17,7 +17,31 @@ import urllib.parse
 
 # Module-level caches
 _msal_app_cache = {}  # (client_id, tenant_id) -> PublicClientApplication
-_tenant_cache = {}  # domain -> tenant_id
+_tenant_cache = {}  # (domain, account_type) -> tenant_id
+
+MICROSOFT_ACCOUNT_TYPES = ("auto", "personal", "work")
+PERSONAL_MICROSOFT_DOMAINS = frozenset(
+    {
+        "hotmail.com",
+        "outlook.com",
+        "live.com",
+        "msn.com",
+        "hotmail.co.uk",
+        "outlook.co.uk",
+        "live.co.uk",
+        "hotmail.fr",
+        "outlook.fr",
+        "hotmail.de",
+        "outlook.de",
+    }
+)
+CONSUMER_TENANTS = frozenset({"consumers", "9188040d-6c67-4c5b-b112-36a304b66dad"})
+
+
+def get_imap_scopes(tenant_id):
+    """Return the delegated IMAP scope appropriate for a Microsoft tenant."""
+    resource_host = "outlook.office.com" if tenant_id.lower() in CONSUMER_TENANTS else "outlook.office365.com"
+    return [f"https://{resource_host}/IMAP.AccessAsUser.All"]
 
 
 def _fetch_json_https(host, path, timeout=10):
@@ -59,30 +83,36 @@ def _fetch_json_https(host, path, timeout=10):
     return json.loads(body.decode("utf-8"))
 
 
-def discover_tenant(email):
+def discover_tenant(email, account_type="auto"):
     """
     Auto-discovers the Microsoft tenant ID from an email address domain.
     Uses the OpenID Connect discovery endpoint (no authentication required).
     Results are cached per domain to avoid repeated network requests.
     Returns the tenant ID string or None if discovery fails.
     """
+    account_type = account_type.strip().lower()
+    if account_type not in MICROSOFT_ACCOUNT_TYPES:
+        choices = ", ".join(MICROSOFT_ACCOUNT_TYPES)
+        raise ValueError(f"Invalid Microsoft account type '{account_type}'; expected one of: {choices}")
+
+    if account_type == "personal":
+        return "consumers"
+
     domain = email.split("@")[-1].strip().lower()
     if not domain:
         print("Error: Could not discover Microsoft tenant: missing email domain")
         return None
 
-    # Return cached tenant if available
-    if domain in _tenant_cache:
-        return _tenant_cache[domain]
+    cache_key = (domain, account_type)
+    if cache_key in _tenant_cache:
+        return _tenant_cache[cache_key]
 
     # Personal Microsoft accounts (live.com identity provider) live in the
     # "consumers" tenant. Auto-discovery via login.microsoftonline.com for
     # these domains returns a Microsoft-internal work/school tenant that
     # rejects personal accounts with AADSTS50020. Short-circuit here.
-    if domain in ("hotmail.com", "outlook.com", "live.com", "msn.com",
-                  "hotmail.co.uk", "outlook.co.uk", "live.co.uk",
-                  "hotmail.fr", "outlook.fr", "hotmail.de", "outlook.de"):
-        _tenant_cache[domain] = "consumers"
+    if account_type == "auto" and domain in PERSONAL_MICROSOFT_DOMAINS:
+        _tenant_cache[cache_key] = "consumers"
         return "consumers"
 
     domain_quoted = urllib.parse.quote(domain, safe=".-")
@@ -99,14 +129,14 @@ def discover_tenant(email):
     match = re.search(r"/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})", issuer)
     if match:
         tenant_id = match.group(1)
-        _tenant_cache[domain] = tenant_id
+        _tenant_cache[cache_key] = tenant_id
         return tenant_id
 
     print(f"Error: Could not extract tenant ID from issuer: {issuer}")
     return None
 
 
-def acquire_token(client_id, email):
+def acquire_token(client_id, email, account_type="auto"):
     """
     Acquires a Microsoft OAuth2 access token using the MSAL device code flow.
     Auto-discovers tenant ID from the email domain.
@@ -115,7 +145,7 @@ def acquire_token(client_id, email):
     On subsequent calls, silently refreshes the token using the cached MSAL app
     (which holds the refresh token in its in-memory cache).
     """
-    tenant_id = discover_tenant(email)
+    tenant_id = discover_tenant(email, account_type)
     if not tenant_id:
         return None
 
@@ -132,8 +162,7 @@ def acquire_token(client_id, email):
         authority = f"https://login.microsoftonline.com/{tenant_id}"
     # Personal accounts (consumers tenant) require the outlook.office.com
     # resource URL, not outlook.office365.com, or AADSTS70011 fires.
-    resource_host = "outlook.office.com" if tenant_id == "consumers" else "outlook.office365.com"
-    scopes = [f"https://{resource_host}/IMAP.AccessAsUser.All"]
+    scopes = get_imap_scopes(tenant_id)
 
     # Reuse cached MSAL app so acquire_token_silent can access refresh tokens
     cache_key = (client_id, tenant_id)

--- a/src/core/imap_session.py
+++ b/src/core/imap_session.py
@@ -9,7 +9,7 @@ from auth import imap_oauth2
 from utils import imap_common
 
 
-def build_imap_conf(host, user, password, client_id=None, client_secret=None, label=None):
+def build_imap_conf(host, user, password, client_id=None, client_secret=None, account_type="auto", label=None):
     """
     Build a standard IMAP connection config dict.
 
@@ -22,6 +22,7 @@ def build_imap_conf(host, user, password, client_id=None, client_secret=None, la
         password: IMAP password (used for password auth or as fallback)
         client_id: OAuth2 client ID (triggers OAuth2 flow if provided)
         client_secret: OAuth2 client secret (required for Google)
+        account_type: Provider account type (currently auto, personal, or work for Microsoft)
         label: Optional context label for status messages (e.g. "source", "destination")
 
     Returns:
@@ -32,12 +33,20 @@ def build_imap_conf(host, user, password, client_id=None, client_secret=None, la
     oauth2_info = None
 
     if client_id:
-        oauth2_token, oauth2_provider = imap_oauth2.acquire_token(host, client_id, user, client_secret, label)
+        oauth2_token, oauth2_provider = imap_oauth2.acquire_token(
+            host,
+            client_id,
+            user,
+            client_secret,
+            label,
+            account_type=account_type,
+        )
         oauth2_info = {
             "provider": oauth2_provider,
             "client_id": client_id,
             "email": user,
             "client_secret": client_secret,
+            "account_type": account_type,
         }
 
     return {

--- a/src/imap_backup.py
+++ b/src/imap_backup.py
@@ -722,6 +722,12 @@ def main():
         dest="src_client_secret",
         help="OAuth2 Client Secret (if required) (or SRC_OAUTH2_CLIENT_SECRET)",
     )
+    parser.add_argument(
+        "--src-account-type",
+        choices=("auto", "personal", "work"),
+        default=os.getenv("SRC_ACCOUNT_TYPE", "auto"),
+        help="Source OAuth provider account type (auto, personal, or work; or SRC_ACCOUNT_TYPE)",
+    )
 
     # Destination (Local Path)
     env_path = os.getenv("BACKUP_LOCAL_PATH")
@@ -785,7 +791,12 @@ def main():
 
     # Build connection config (acquires OAuth2 token if configured)
     src_conf = imap_session.build_imap_conf(
-        args.src_host, args.src_user, args.src_pass, args.src_client_id, args.src_client_secret
+        args.src_host,
+        args.src_user,
+        args.src_pass,
+        args.src_client_id,
+        args.src_client_secret,
+        account_type=args.src_account_type,
     )
 
     # Expand path (~/...)

--- a/src/imap_compare.py
+++ b/src/imap_compare.py
@@ -149,6 +149,12 @@ def main():
         dest="src_client_secret",
         help="Source OAuth2 Client Secret (if required) (or SRC_OAUTH2_CLIENT_SECRET)",
     )
+    parser.add_argument(
+        "--src-account-type",
+        choices=("auto", "personal", "work"),
+        default=os.getenv("SRC_ACCOUNT_TYPE", "auto"),
+        help="Source OAuth provider account type (auto, personal, or work; or SRC_ACCOUNT_TYPE)",
+    )
 
     # Dest args
     default_dest_host = os.getenv("DEST_IMAP_HOST")
@@ -199,6 +205,12 @@ def main():
         dest="dest_client_secret",
         help=argparse.SUPPRESS,
     )
+    parser.add_argument(
+        "--dest-account-type",
+        choices=("auto", "personal", "work"),
+        default=os.getenv("DEST_ACCOUNT_TYPE", "auto"),
+        help="Destination OAuth provider account type (auto, personal, or work; or DEST_ACCOUNT_TYPE)",
+    )
 
     args = parser.parse_args()
 
@@ -215,14 +227,24 @@ def main():
     src_oauth2_provider = None
     if not src_is_local and args.src_client_id:
         src_oauth2_token, src_oauth2_provider = imap_oauth2.acquire_token(
-            SRC_HOST, args.src_client_id, SRC_USER, args.src_client_secret, "source"
+            SRC_HOST,
+            args.src_client_id,
+            SRC_USER,
+            args.src_client_secret,
+            "source",
+            args.src_account_type,
         )
 
     dest_oauth2_token = None
     dest_oauth2_provider = None
     if not dest_is_local and args.dest_client_id:
         dest_oauth2_token, dest_oauth2_provider = imap_oauth2.acquire_token(
-            DEST_HOST, args.dest_client_id, DEST_USER, args.dest_client_secret, "destination"
+            DEST_HOST,
+            args.dest_client_id,
+            DEST_USER,
+            args.dest_client_secret,
+            "destination",
+            args.dest_account_type,
         )
 
     print("\n--- Configuration Summary ---")

--- a/src/imap_count.py
+++ b/src/imap_count.py
@@ -200,6 +200,12 @@ def main(argv: Optional[list[str]] = None) -> None:
         help="OAuth2 Client Secret (if required) (or OAUTH2_CLIENT_SECRET / SRC_OAUTH2_CLIENT_SECRET)",
     )
     parser.add_argument(
+        "--account-type",
+        choices=("auto", "personal", "work"),
+        default=os.getenv("ACCOUNT_TYPE", "auto"),
+        help="OAuth provider account type (auto, personal, or work; or ACCOUNT_TYPE)",
+    )
+    parser.add_argument(
         "--client-secret",
         default=os.getenv("OAUTH2_CLIENT_SECRET") or os.getenv("SRC_OAUTH2_CLIENT_SECRET"),
         dest="client_secret",
@@ -228,7 +234,11 @@ def main(argv: Optional[list[str]] = None) -> None:
     oauth2_provider = None
     if args.client_id:
         oauth2_token, oauth2_provider = imap_oauth2.acquire_token(
-            IMAP_SERVER, args.client_id, USERNAME, args.client_secret
+            IMAP_SERVER,
+            args.client_id,
+            USERNAME,
+            args.client_secret,
+            account_type=args.account_type,
         )
 
     print("\n--- Configuration Summary ---")

--- a/src/imap_migrate.py
+++ b/src/imap_migrate.py
@@ -798,6 +798,12 @@ def main():
         dest="src_client_secret",
         help="Source OAuth2 Client Secret (if required) (or SRC_OAUTH2_CLIENT_SECRET)",
     )
+    parser.add_argument(
+        "--src-account-type",
+        choices=("auto", "personal", "work"),
+        default=os.getenv("SRC_ACCOUNT_TYPE", "auto"),
+        help="Source OAuth provider account type (auto, personal, or work; or SRC_ACCOUNT_TYPE)",
+    )
 
     # Dest args
     default_dest_host = os.getenv("DEST_IMAP_HOST")
@@ -847,6 +853,12 @@ def main():
         default=os.getenv("DEST_OAUTH2_CLIENT_SECRET"),
         dest="dest_client_secret",
         help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--dest-account-type",
+        choices=("auto", "personal", "work"),
+        default=os.getenv("DEST_ACCOUNT_TYPE", "auto"),
+        help="Destination OAuth provider account type (auto, personal, or work; or DEST_ACCOUNT_TYPE)",
     )
 
     # Options
@@ -941,10 +953,22 @@ def main():
 
     # Build connection configs (acquires OAuth2 tokens if configured)
     src_conf = imap_session.build_imap_conf(
-        SRC_HOST, SRC_USER, SRC_PASS, args.src_client_id, args.src_client_secret, "source"
+        SRC_HOST,
+        SRC_USER,
+        SRC_PASS,
+        args.src_client_id,
+        args.src_client_secret,
+        args.src_account_type,
+        "source",
     )
     dest_conf = imap_session.build_imap_conf(
-        DEST_HOST, DEST_USER, DEST_PASS, args.dest_client_id, args.dest_client_secret, "destination"
+        DEST_HOST,
+        DEST_USER,
+        DEST_PASS,
+        args.dest_client_id,
+        args.dest_client_secret,
+        args.dest_account_type,
+        "destination",
     )
 
     print("\n--- Configuration Summary ---")

--- a/src/imap_restore.py
+++ b/src/imap_restore.py
@@ -757,6 +757,12 @@ def main():
         dest="dest_client_secret",
         help=argparse.SUPPRESS,
     )
+    parser.add_argument(
+        "--dest-account-type",
+        choices=("auto", "personal", "work"),
+        default=os.getenv("DEST_ACCOUNT_TYPE", "auto"),
+        help="Destination OAuth provider account type (auto, personal, or work; or DEST_ACCOUNT_TYPE)",
+    )
 
     # Config
     parser.add_argument(
@@ -823,7 +829,13 @@ def main():
 
     # Build connection config (acquires OAuth2 token if configured)
     dest_conf = imap_session.build_imap_conf(
-        args.dest_host, args.dest_user, args.dest_pass, args.dest_client_id, args.dest_client_secret, "destination"
+        args.dest_host,
+        args.dest_user,
+        args.dest_pass,
+        args.dest_client_id,
+        args.dest_client_secret,
+        args.dest_account_type,
+        "destination",
     )
 
     # Expand path

--- a/test/auth/test_imap_oauth2.py
+++ b/test/auth/test_imap_oauth2.py
@@ -108,6 +108,17 @@ class TestAcquireOauth2TokenForProvider:
         assert "Unknown OAuth2 provider" in captured.out
 
 
+class TestCompatibilityHelpers:
+    def test_microsoft_token_helper_forwards_account_type(self):
+        with patch.object(oauth2_microsoft, "acquire_token", return_value="ms_token") as acquire:
+            result = imap_oauth2.acquire_microsoft_oauth2_token(
+                "client-id", "user@example.com", account_type="personal"
+            )
+
+        assert result == "ms_token"
+        acquire.assert_called_once_with("client-id", "user@example.com", "personal")
+
+
 class TestRefreshOauth2Token:
     """Tests for thread-safe refresh_oauth2_token function."""
 

--- a/test/auth/test_imap_oauth2.py
+++ b/test/auth/test_imap_oauth2.py
@@ -72,7 +72,16 @@ class TestAcquireOauth2TokenForProvider:
             result = imap_oauth2.acquire_oauth2_token_for_provider("microsoft", "cid", "user@test.com")
 
         assert result == "ms_token"
-        mock_ms.assert_called_once_with("cid", "user@test.com")
+        mock_ms.assert_called_once_with("cid", "user@test.com", "auto")
+
+    def test_dispatches_account_type(self):
+        with patch.object(oauth2_microsoft, "acquire_token", return_value="ms_token") as mock_ms:
+            result = imap_oauth2.acquire_oauth2_token_for_provider(
+                "microsoft", "cid", "user@example.com", account_type="personal"
+            )
+
+        assert result == "ms_token"
+        mock_ms.assert_called_once_with("cid", "user@example.com", "personal")
 
     def test_dispatch_to_google(self):
         """Test dispatches to Google when provider is 'google'."""
@@ -122,7 +131,7 @@ class TestRefreshOauth2Token:
 
         assert result == "new_token"
         assert conf["oauth2_token"] == "new_token"
-        mock_acquire.assert_called_once_with("microsoft", "client-id", "user@test.com", None)
+        mock_acquire.assert_called_once_with("microsoft", "client-id", "user@test.com", None, account_type="auto")
 
     def test_skips_refresh_when_token_already_updated(self):
         """Test that refresh is skipped if another thread already updated the token."""
@@ -202,7 +211,7 @@ class TestRefreshOauth2Token:
         call_count = {"value": 0}
         barrier = threading.Barrier(3)  # 3 threads
 
-        def slow_acquire(provider, client_id, email, client_secret):
+        def slow_acquire(provider, client_id, email, client_secret, account_type="auto"):
             call_count["value"] += 1
             time.sleep(0.05)  # Simulate network delay
             return "fresh_token"
@@ -391,7 +400,7 @@ class TestAcquireToken:
         with patch.object(imap_oauth2, "acquire_oauth2_token_for_provider", return_value="tok") as mock_acq:
             imap_oauth2.acquire_token("imap.gmail.com", "cid", "user@gmail.com", client_secret="my_secret")
 
-        mock_acq.assert_called_once_with("google", "cid", "user@gmail.com", "my_secret")
+        mock_acq.assert_called_once_with("google", "cid", "user@gmail.com", "my_secret", account_type="auto")
 
 
 class TestAuthDescription:

--- a/test/auth/test_oauth2_microsoft.py
+++ b/test/auth/test_oauth2_microsoft.py
@@ -20,6 +20,20 @@ from auth import oauth2_microsoft
 from conftest import temp_env
 from mock_oauth_server import MOCK_TENANT_ID
 
+EXPECTED_PERSONAL_MICROSOFT_DOMAINS = {
+    "hotmail.com",
+    "outlook.com",
+    "live.com",
+    "msn.com",
+    "hotmail.co.uk",
+    "outlook.co.uk",
+    "live.co.uk",
+    "hotmail.fr",
+    "outlook.fr",
+    "hotmail.de",
+    "outlook.de",
+}
+
 
 @pytest.fixture(autouse=True)
 def clear_caches():
@@ -110,6 +124,59 @@ class TestDiscoverTenant:
             result = oauth2_microsoft.discover_tenant("user@example.org")
 
         assert result == MOCK_TENANT_ID
+
+    def test_personal_domain_allowlist_matches_expected_domains(self):
+        assert oauth2_microsoft.PERSONAL_MICROSOFT_DOMAINS == EXPECTED_PERSONAL_MICROSOFT_DOMAINS
+
+    @pytest.mark.parametrize("domain", sorted(EXPECTED_PERSONAL_MICROSOFT_DOMAINS))
+    def test_auto_recognizes_known_personal_domains(self, domain):
+        assert oauth2_microsoft.discover_tenant(f"user@{domain}") == "consumers"
+
+    def test_auto_does_not_classify_unknown_domain_as_personal(self, mock_oauth_server):
+        with temp_env({"OAUTH2_MICROSOFT_DISCOVERY_URL": mock_oauth_server}):
+            result = oauth2_microsoft.discover_tenant("user@not-personal.example", "auto")
+
+        assert result == MOCK_TENANT_ID
+
+    def test_personal_supports_non_microsoft_email_without_discovery(self):
+        with temp_env({"OAUTH2_MICROSOFT_DISCOVERY_URL": "http://127.0.0.1:1"}):
+            result = oauth2_microsoft.discover_tenant("user@example.org", "personal")
+
+        assert result == "consumers"
+
+    def test_work_forces_real_discovery_for_known_personal_domain(self, mock_oauth_server):
+        with temp_env({"OAUTH2_MICROSOFT_DISCOVERY_URL": mock_oauth_server}):
+            result = oauth2_microsoft.discover_tenant("user@hotmail.com", "work")
+
+        assert result == MOCK_TENANT_ID
+
+    def test_work_override_is_not_polluted_by_auto_cache(self, mock_oauth_server):
+        assert oauth2_microsoft.discover_tenant("user@hotmail.com", "auto") == "consumers"
+
+        with temp_env({"OAUTH2_MICROSOFT_DISCOVERY_URL": mock_oauth_server}):
+            result = oauth2_microsoft.discover_tenant("user@hotmail.com", "work")
+
+        assert result == MOCK_TENANT_ID
+
+    def test_invalid_account_type_is_rejected(self):
+        with pytest.raises(ValueError, match="Invalid Microsoft account type"):
+            oauth2_microsoft.discover_tenant("user@example.org", "unknown")
+
+
+class TestImapScopes:
+    @pytest.mark.parametrize(
+        ("tenant", "expected_scope"),
+        [
+            ("consumers", "https://outlook.office.com/IMAP.AccessAsUser.All"),
+            (
+                "9188040d-6c67-4c5b-b112-36a304b66dad",
+                "https://outlook.office.com/IMAP.AccessAsUser.All",
+            ),
+            ("tenant-123", "https://outlook.office365.com/IMAP.AccessAsUser.All"),
+        ],
+    )
+    def test_tenant_selects_expected_scope(self, tenant, expected_scope):
+        assert oauth2_microsoft.get_imap_scopes(tenant) == [expected_scope]
 
 
 class TestAcquireToken:

--- a/test/core/test_imap_session.py
+++ b/test/core/test_imap_session.py
@@ -44,7 +44,14 @@ class TestBuildImapConf:
                 label="source",
             )
 
-        mock_acquire.assert_called_once_with("outlook.office365.com", "cid", "user@example.com", "csecret", "source")
+        mock_acquire.assert_called_once_with(
+            "outlook.office365.com",
+            "cid",
+            "user@example.com",
+            "csecret",
+            "source",
+            account_type="auto",
+        )
         assert conf["host"] == "outlook.office365.com"
         assert conf["user"] == "user@example.com"
         assert conf["password"] == "pass"
@@ -54,6 +61,7 @@ class TestBuildImapConf:
             "client_id": "cid",
             "email": "user@example.com",
             "client_secret": "csecret",
+            "account_type": "auto",
         }
 
     def test_no_client_id_skips_oauth2(self):
@@ -87,7 +95,34 @@ class TestBuildImapConf:
                 "imap.gmail.com", "user@gmail.com", "pass", client_id="cid", client_secret="sec", label="destination"
             )
 
-        mock_acquire.assert_called_once_with("imap.gmail.com", "cid", "user@gmail.com", "sec", "destination")
+        mock_acquire.assert_called_once_with(
+            "imap.gmail.com",
+            "cid",
+            "user@gmail.com",
+            "sec",
+            "destination",
+            account_type="auto",
+        )
+
+    def test_account_type_is_forwarded_and_stored(self):
+        with patch.object(imap_session.imap_oauth2, "acquire_token", return_value=("tok", "microsoft")) as mock_acquire:
+            conf = imap_session.build_imap_conf(
+                "outlook.office365.com",
+                "user@example.com",
+                None,
+                client_id="cid",
+                account_type="personal",
+            )
+
+        mock_acquire.assert_called_once_with(
+            "outlook.office365.com",
+            "cid",
+            "user@example.com",
+            None,
+            None,
+            account_type="personal",
+        )
+        assert conf["oauth2"]["account_type"] == "personal"
 
 
 class TestEnsureConnection:


### PR DESCRIPTION
## Summary

- add generic `account_type` configuration with `auto`, `personal`, and `work` values
- expose `--account-type`, `--src-account-type`, and `--dest-account-type` across the CLI tools
- automatically recognize common personal Microsoft email domains
- allow personal Microsoft accounts using arbitrary email domains to explicitly select `personal`
- allow `work` to force organizational discovery even for normally personal domains
- preserve account type across OAuth token refreshes and reconnects
- isolate tenant caching by email domain and account type
- select the personal-compatible IMAP scope for both the `consumers` alias and consumer tenant UUID
- document CLI and environment configuration

## Testing

Coverage includes:

- independent verification of the known personal-domain allowlist
- personal accounts with non-Microsoft email domains
- work-account discovery through the local OpenID server
- work override after an automatic personal-domain result
- unknown-domain organizational discovery
- consumer alias, consumer UUID, and organizational scope selection
- OAuth dispatch, refresh, and session configuration propagation
- affected backup, restore, migrate, compare, and count CLI tests

## Verification

- affected suite: 270 passed
- full suite during implementation: 463 passed
- `.venv/bin/python -m ruff check src/ tools/ test/`
- `.venv/bin/python -m ruff format --check src/ tools/ test/`
- `git diff --check`

Follow-up to #42.