### PR TITLE
OAuth2 token caching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,8 @@ IMAP_PASSWORD=""
 OAUTH2_CLIENT_ID=""
 OAUTH2_CLIENT_SECRET=""
 ACCOUNT_TYPE="auto"  # OAuth provider account type: auto, personal, or work (imap-count)
+OAUTH2_CACHE_ENABLED="true"  # Set false to disable persistent OAuth2 token caching
+OAUTH2_CACHE_DIR=""  # Optional OAuth2 token-cache directory
 
 # Microsoft account type overrides for dual-account scripts
 SRC_ACCOUNT_TYPE="auto"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install .
           pip install pytest pytest-cov python-dotenv
 
       - name: Run tests with coverage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,14 @@
 
 ## Development workflow
 
+Before implementing a new feature, investigate whether a maintained library
+already provides the complete feature or important building blocks. Present
+the user with the viable options before implementation: add a dependency and
+use the existing library, or implement the behavior from scratch, including
+the relevant maintenance, security, and portability tradeoffs. Prefer an
+established library for security- and data-sensitive concerns such as
+authentication, encryption, caching, and database access.
+
 Use Python 3.9+ and run commands from the repository root. The source tree is not installed during tests, so include `PYTHONPATH=src` when invoking pytest directly.
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Use Python 3.9+ and run commands from the repository root. The source tree is no
 
 ```bash
 python3 -m venv .venv
+.venv/bin/python -m pip install -e .  # install declared runtime dependencies
 .venv/bin/python -m pip install -r requirements.txt
 .venv/bin/python -m pip install python-dotenv  # required by .env integration tests
 PYTHONPATH=src .venv/bin/python -m pytest test/ -v
@@ -32,12 +33,47 @@ PYTHONPATH=src .venv/bin/python -m pytest test/ -v
 
 Tests use local mock IMAP servers and bind loopback ports. In restricted environments, rerun them with the permission needed for local socket binding rather than changing the tests to avoid integration coverage.
 
+CI test jobs must install the project (for example, `pip install .`) before
+running pytest. Installing test tools alone can hide missing runtime
+dependencies locally and cause collection failures in the clean CI matrix.
+
 ## Code conventions
 
 - Target Python 3.9 compatibility. Follow the Ruff configuration in `pyproject.toml` (120-column lines, double quotes, and sorted imports).
 - Use concise module and function docstrings. Place reusable behavior in the existing subsystem directories rather than duplicating it in CLI files.
 - Preserve CLI compatibility: command-line options, environment variables, and legacy wrapper scripts are public interfaces.
+- When renaming shared or module-level symbols, search the entire source and test trees for compatibility aliases and re-exports before running tests.
 - Keep sensitive values out of version control. `.env` is ignored; `.env.example` is the committed, non-secret template.
+
+## OAuth2 caching
+
+- Keep process-local and persistent OAuth2 caching behind
+  `src/auth/oauth2_cache.py`. Provider-specific authentication modules should
+  consume that interface and must not implement cache paths, encryption,
+  locking, or persistence directly.
+- The current cache implementation uses MSAL Extensions. Use only its
+  platform-encrypted persistence; never add a plaintext token-cache fallback.
+  If encryption or the cache library is unavailable, authentication must
+  continue with process-local caching only and provide concise installation or
+  diagnostic guidance.
+- Use `OAUTH2_CACHE_ENABLED` and `OAUTH2_CACHE_DIR` for shared cache
+  configuration. Keep cache settings provider-neutral so additional OAuth2
+  providers can reuse them.
+- Treat cached access tokens, refresh tokens, serialized credentials, and
+  client secrets as sensitive. Partition entries by provider, client, and
+  normalized account identity; use non-identifying hashed filenames and
+  cross-process locking.
+- Keep terminology precise: an MSAL `PublicClientApplication` is an
+  application object, while the persistent token cache stores credentials.
+  Avoid using a generic name such as `cache` for both concepts.
+- Import optional provider dependencies at the point of use and convert a
+  missing dependency into a short, actionable installation message rather
+  than an import traceback.
+- Put backend behavior tests in `test/auth/test_oauth2_cache.py`. Exercise the
+  real persistence and locking library with temporary data where practical;
+  provider authentication tests may isolate external browser and identity
+  service boundaries. Ensure tests never access the developer's real
+  credential store.
 
 ## `.env` configuration
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ This repository contains a set of Python scripts designed to migrate emails betw
 - **Optional:** To use a `.env` file, install the `python-dotenv` package as well:
   - `pip install python-dotenv`
 
-- **Optional: OAuth2 authentication** requires one additional package depending on your provider:
-  - **Microsoft (Outlook/Office 365):** `pip install msal`
+- **Optional: OAuth2 authentication** requires provider-specific packages:
+  - **Microsoft (Outlook/Office 365):** `pip install msal msal-extensions`
   - **Google (Gmail):** `pip install google-auth-oauthlib`
 
 ### 2. Installation
@@ -715,9 +715,17 @@ Environment variable equivalents:
 - Dual-account scripts: `SRC_OAUTH2_CLIENT_ID`, `SRC_OAUTH2_CLIENT_SECRET` and `DEST_OAUTH2_CLIENT_ID`, `DEST_OAUTH2_CLIENT_SECRET`.
 - Single-account scripts (like `imap_count.py`): `OAUTH2_CLIENT_ID`, `OAUTH2_CLIENT_SECRET` (also accepts `SRC_OAUTH2_CLIENT_ID`, `SRC_OAUTH2_CLIENT_SECRET`).
 
+Microsoft and Google authentication share an encrypted persistent token cache
+implemented with MSAL Extensions. Cache entries are isolated by provider,
+client, and account, and concurrent access is protected by locking. Set
+`OAUTH2_CACHE_DIR` to override its location, or
+`OAUTH2_CACHE_ENABLED=false` to disable persistent token caching. Tokens are
+never persisted in plaintext. If platform encryption is unavailable,
+authentication continues with an in-memory cache for the current process only.
+
 ### Microsoft (Outlook / Office 365)
 
-Requires the `msal` package (`pip install msal`). Uses the **device code flow** — no browser redirect needed. The tenant ID is auto-discovered from the user's email domain.
+Requires `msal` and `msal-extensions` (`pip install msal msal-extensions`). Uses the **device code flow** — no browser redirect needed. The tenant ID is auto-discovered from the user's email domain.
 
 #### Creating an App Registration in Microsoft Entra
 
@@ -748,8 +756,12 @@ Requires the `msal` package (`pip install msal`). Uses the **device code flow** 
 #### Usage
 
 ```bash
-# Install dependency
-pip install msal
+# Install dependencies
+pip install msal msal-extensions
+
+# Enable the encrypted persistent token cache and optionally choose its location
+export OAUTH2_CACHE_ENABLED="true"
+export OAUTH2_CACHE_DIR="/path/to/private/oauth2-cache"
 
 # Migration with Microsoft OAuth2 on source
 python3 imap_migrate.py \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 dependencies = [
     "google-auth-oauthlib",
     "msal",
+    "msal-extensions>=1.3.1",
 ]
 
 [project.optional-dependencies]

--- a/src/auth/imap_oauth2.py
+++ b/src/auth/imap_oauth2.py
@@ -13,8 +13,6 @@ import threading
 from auth import oauth2_google, oauth2_microsoft
 
 # Re-export caches for test access
-_msal_app_cache = oauth2_microsoft._msal_app_cache
-_google_creds_cache = oauth2_google._creds_cache
 _tenant_cache = oauth2_microsoft._tenant_cache
 
 # Thread-safe token refresh
@@ -79,12 +77,12 @@ def acquire_microsoft_oauth2_token(client_id, email, account_type="auto"):
     return oauth2_microsoft.acquire_token(client_id, email, account_type)
 
 
-def acquire_google_oauth2_token(client_id, client_secret):
+def acquire_google_oauth2_token(client_id, client_secret, email=None):
     """
     Acquires a Google OAuth2 access token using the installed app flow.
     Delegates to oauth2_google module.
     """
-    return oauth2_google.acquire_token(client_id, client_secret)
+    return oauth2_google.acquire_token(client_id, client_secret, email)
 
 
 def acquire_oauth2_token_for_provider(provider, client_id, email, client_secret=None, account_type="auto"):
@@ -107,7 +105,7 @@ def acquire_oauth2_token_for_provider(provider, client_id, email, client_secret=
                 "or set OAUTH2_CLIENT_SECRET / SRC_OAUTH2_CLIENT_SECRET / DEST_OAUTH2_CLIENT_SECRET."
             )
             return None
-        return oauth2_google.acquire_token(client_id, client_secret)
+        return oauth2_google.acquire_token(client_id, client_secret, email)
     else:
         print(f"Error: Unknown OAuth2 provider: {provider}")
         return None

--- a/src/auth/oauth2_cache.py
+++ b/src/auth/oauth2_cache.py
@@ -1,0 +1,122 @@
+"""Provider-neutral OAuth2 caching backed by encrypted MSAL Extensions storage."""
+
+import hashlib
+import os
+import sys
+
+
+class MsalExtensionsOAuth2CacheProvider:
+    """Provide process-local and encrypted persistent caches for OAuth2 providers."""
+
+    def __init__(self, encrypted_persistence_builder=None):
+        self._memory = {}
+        self._encrypted_persistence_builder = encrypted_persistence_builder
+
+    def get(self, namespace, key):
+        """Return a process-local cached object."""
+        return self._memory.get((namespace, key))
+
+    def set(self, namespace, key, value):
+        """Store an object in the process-local cache."""
+        self._memory[(namespace, key)] = value
+
+    def clear_memory(self):
+        """Clear process-local cached objects."""
+        self._memory.clear()
+
+    def persistent_cache_enabled(self):
+        """Return whether encrypted persistent caching is enabled."""
+        value = os.getenv("OAUTH2_CACHE_ENABLED", "true")
+        return value.strip().lower() not in {"0", "false", "no", "off"}
+
+    def cache_path(self, namespace, *identity_parts):
+        """Return a collision-resistant, non-identifying cache path."""
+        identity = "\0".join(str(part).strip().casefold() for part in identity_parts)
+        digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()
+        return os.path.join(self._cache_dir(), f"{namespace}-{digest}.cache")
+
+    def create_token_cache(self, namespace, *identity_parts):
+        """Create an MSAL-compatible encrypted persistent token cache."""
+        persistence = self._create_encrypted_persistence(namespace, *identity_parts)
+        if persistence is None:
+            return None
+        from msal_extensions import PersistedTokenCache
+
+        return PersistedTokenCache(persistence)
+
+    def load(self, namespace, *identity_parts):
+        """Load a string from encrypted persistent storage."""
+        persistence = self._create_encrypted_persistence(namespace, *identity_parts)
+        if persistence is None:
+            return None
+        from msal_extensions import CrossPlatLock
+        from msal_extensions.persistence import PersistenceNotFound
+
+        try:
+            with CrossPlatLock(f"{persistence.get_location()}.lockfile"):
+                return persistence.load()
+        except PersistenceNotFound:
+            return None
+        except Exception as e:
+            print(f"Warning: Could not load the {namespace} persistent token cache: {e}")
+            return None
+
+    def save(self, namespace, value, *identity_parts):
+        """Save a string to encrypted persistent storage."""
+        persistence = self._create_encrypted_persistence(namespace, *identity_parts)
+        if persistence is None:
+            return False
+        from msal_extensions import CrossPlatLock
+
+        try:
+            with CrossPlatLock(f"{persistence.get_location()}.lockfile"):
+                persistence.save(value)
+            return True
+        except Exception as e:
+            print(f"Warning: Could not save the {namespace} persistent token cache: {e}")
+            return False
+
+    def _cache_dir(self):
+        configured = os.getenv("OAUTH2_CACHE_DIR")
+        if configured:
+            return configured
+        if sys.platform == "win32":
+            root = os.getenv("LOCALAPPDATA") or os.path.expanduser("~")
+        elif sys.platform == "darwin":
+            root = os.path.expanduser("~/Library/Caches")
+        else:
+            root = os.getenv("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
+        return os.path.join(root, "imap-migration-tools")
+
+    def _create_encrypted_persistence(self, namespace, *identity_parts):
+        if not self.persistent_cache_enabled():
+            return None
+
+        try:
+            from msal_extensions import build_encrypted_persistence
+        except ImportError:
+            print("Warning: Persistent OAuth2 caching requires: pip install msal-extensions")
+            return None
+
+        cache_path = self.cache_path(namespace, *identity_parts)
+        cache_dir = os.path.dirname(cache_path)
+        cache_dir_existed = os.path.isdir(cache_dir)
+        try:
+            os.makedirs(cache_dir, mode=0o700, exist_ok=True)
+            if os.name == "posix" and not cache_dir_existed:
+                os.chmod(cache_dir, 0o700)
+        except OSError as e:
+            print(f"Warning: Persistent token caching is disabled because {cache_dir} is unavailable: {e}")
+            return None
+
+        builder = self._encrypted_persistence_builder or build_encrypted_persistence
+        try:
+            return builder(cache_path)
+        except Exception as e:
+            print(
+                f"Warning: Encrypted token caching is unavailable ({e}). Continuing without persistent token caching."
+            )
+            return None
+
+
+oauth2_cache = MsalExtensionsOAuth2CacheProvider()

--- a/src/auth/oauth2_google.py
+++ b/src/auth/oauth2_google.py
@@ -7,14 +7,16 @@ Opens a browser for user consent and runs a local HTTP server for the redirect.
 Requires the 'google-auth-oauthlib' package: pip install google-auth-oauthlib
 """
 
+import json
 import os
 import sys
 
-# Module-level cache for credentials (holds refresh token)
-_creds_cache = {}  # (client_id, client_secret) -> credentials
+from auth.oauth2_cache import oauth2_cache
+
+GOOGLE_IMAP_SCOPES = ["https://mail.google.com/"]
 
 
-def acquire_token(client_id, client_secret):
+def acquire_token(client_id, client_secret, email=None):
     """
     Acquires a Google OAuth2 access token using the installed app flow.
     Opens a browser for user consent and runs a local HTTP server for the redirect.
@@ -23,26 +25,38 @@ def acquire_token(client_id, client_secret):
     On subsequent calls, silently refreshes the token using the cached credentials
     object (which holds the refresh token). No browser interaction needed for refresh.
     """
-    # Try refreshing cached credentials first (no browser needed)
-    cache_key = (client_id, client_secret)
-    if cache_key in _creds_cache:
-        creds = _creds_cache[cache_key]
-        if creds and creds.refresh_token:
-            try:
-                import google.auth.transport.requests
-
-                creds.refresh(google.auth.transport.requests.Request())
-                if creds.token:
-                    return creds.token
-            except Exception:
-                pass  # Fall through to full auth flow
-
     try:
+        import google.auth.transport.requests
+        from google.oauth2.credentials import Credentials
         from google_auth_oauthlib.flow import InstalledAppFlow
     except ImportError:
         print("Error: 'google-auth-oauthlib' package is required for Google OAuth2.")
         print("Install it with: pip install google-auth-oauthlib")
         sys.exit(1)
+
+    normalized_email = email.strip().casefold() if email else "default"
+    credentials_cache_key = (client_id, normalized_email)
+    credentials = oauth2_cache.get("google_credentials", credentials_cache_key)
+
+    if credentials is None:
+        serialized_credentials = oauth2_cache.load("google", client_id, normalized_email)
+        if serialized_credentials:
+            try:
+                credentials = Credentials.from_authorized_user_info(
+                    json.loads(serialized_credentials), scopes=GOOGLE_IMAP_SCOPES
+                )
+                oauth2_cache.set("google_credentials", credentials_cache_key, credentials)
+            except (TypeError, ValueError) as e:
+                print(f"Warning: Could not restore cached Google credentials: {e}")
+
+    if credentials and credentials.refresh_token:
+        try:
+            credentials.refresh(google.auth.transport.requests.Request())
+            if credentials.token:
+                oauth2_cache.save("google", credentials.to_json(), client_id, normalized_email)
+                return credentials.token
+        except Exception:
+            pass  # Fall through to full auth flow
 
     auth_uri = os.getenv("OAUTH2_GOOGLE_AUTH_URL") or "https://accounts.google.com/o/oauth2/auth"
     token_uri = os.getenv("OAUTH2_GOOGLE_TOKEN_URL") or "https://oauth2.googleapis.com/token"
@@ -57,7 +71,7 @@ def acquire_token(client_id, client_secret):
         }
     }
 
-    flow = InstalledAppFlow.from_client_config(client_config, scopes=["https://mail.google.com/"])
+    flow = InstalledAppFlow.from_client_config(client_config, scopes=GOOGLE_IMAP_SCOPES)
 
     print("Opening browser for Google authentication...")
     print("If the browser does not open, check the terminal for a URL to visit.")
@@ -65,7 +79,8 @@ def acquire_token(client_id, client_secret):
     credentials = flow.run_local_server(port=0)
 
     if credentials and credentials.token:
-        _creds_cache[cache_key] = credentials
+        oauth2_cache.set("google_credentials", credentials_cache_key, credentials)
+        oauth2_cache.save("google", credentials.to_json(), client_id, normalized_email)
         return credentials.token
 
     print("Error: Could not acquire Google OAuth2 token.")

--- a/src/auth/oauth2_microsoft.py
+++ b/src/auth/oauth2_microsoft.py
@@ -4,7 +4,7 @@ Microsoft OAuth2 Token Acquisition
 OAuth2 token acquisition for Microsoft/Outlook IMAP using MSAL device code flow.
 Supports auto-discovery of tenant ID from email domain.
 
-Requires the 'msal' package: pip install msal
+Requires the 'msal' and 'msal-extensions' packages.
 """
 
 import http.client
@@ -15,8 +15,8 @@ import ssl
 import sys
 import urllib.parse
 
-# Module-level caches
-_msal_app_cache = {}  # (client_id, tenant_id) -> PublicClientApplication
+from auth.oauth2_cache import oauth2_cache
+
 _tenant_cache = {}  # (domain, account_type) -> tenant_id
 
 MICROSOFT_ACCOUNT_TYPES = ("auto", "personal", "work")
@@ -136,74 +136,25 @@ def discover_tenant(email, account_type="auto"):
     return None
 
 
-def _msal_cache_path_for(email):
-    """
-    Per-account MSAL token cache path.
-    Contains refresh tokens — permissions restricted to owner (POSIX).
-    Environment override: OAUTH2_MICROSOFT_CACHE_DIR.
-    """
-    cache_dir = os.getenv("OAUTH2_MICROSOFT_CACHE_DIR") or os.path.expanduser("~")
-    safe = re.sub(r"[^a-zA-Z0-9]", "_", email.lower())
-    return os.path.join(cache_dir, f".msal-imap-migrate-{safe}.json")
-
-
-def _load_cache(cache_path, msal_module):
-    """Load a SerializableTokenCache from disk, if it exists."""
-    cache = msal_module.SerializableTokenCache()
-    if os.path.exists(cache_path):
-        try:
-            with open(cache_path, "r", encoding="utf-8") as f:
-                cache.deserialize(f.read())
-        except (OSError, ValueError) as e:
-            print(f"Warning: Could not load MSAL token cache from {cache_path}: {e}")
-    return cache
-
-
-def _save_cache(cache, cache_path):
-    """Persist the cache to disk if it changed, with restrictive permissions.
-
-    On POSIX, the file is created with mode 0600 atomically (via os.open with
-    the O_CREAT flag + mode arg), so refresh-token bytes never touch a
-    world-readable inode. Windows ignores the mode arg — its ACL model is
-    handled separately and defaults to inheriting the parent directory ACL,
-    which is typically the user's profile directory.
-    """
-    if not cache.has_state_changed:
-        return
-    try:
-        # os.open with O_CREAT|O_WRONLY|O_TRUNC and mode 0o600 ensures POSIX
-        # never sees a world-readable moment between file creation and chmod.
-        fd = os.open(
-            cache_path,
-            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-            0o600,
-        )
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(cache.serialize())
-    except OSError as e:
-        print(f"Warning: Could not save MSAL token cache to {cache_path}: {e}")
-
-
 def acquire_token(client_id, email, account_type="auto"):
     """
     Acquires a Microsoft OAuth2 access token using the MSAL device code flow.
     Auto-discovers tenant ID from the email domain.
-    Requires the 'msal' package: pip install msal
+    Requires the 'msal' and 'msal-extensions' packages.
 
-    The token cache is persisted to disk (per email, in the user's home dir
-    by default; override with OAUTH2_MICROSOFT_CACHE_DIR). After the first
-    interactive device-code approval, subsequent process invocations reuse
-    the refresh token silently — enabling cron use. Cache files contain
-    refresh tokens (secrets) and are written with mode 0600 on POSIX.
+    MSAL Extensions persists the per-account token cache with platform
+    encryption, cross-process locking, and automatic reload. Override the
+    cache directory with OAUTH2_CACHE_DIR.
     """
     tenant_id = discover_tenant(email, account_type)
     if not tenant_id:
         return None
+    print(f"Discovered Microsoft tenant: {tenant_id}")
 
     try:
         import msal
     except ImportError:
-        print("Error: 'msal' package is required for Microsoft OAuth2. Install it with: pip install msal")
+        print("Error: Microsoft OAuth2 requires: pip install msal")
         sys.exit(1)
 
     authority_base = os.getenv("OAUTH2_MICROSOFT_AUTHORITY_BASE_URL")
@@ -215,39 +166,34 @@ def acquire_token(client_id, email, account_type="auto"):
     # resource URL, not outlook.office365.com, or AADSTS70011 fires.
     scopes = get_imap_scopes(tenant_id)
 
-    # Load persistent cache — enables non-interactive cron use.
-    cache_path = _msal_cache_path_for(email)
-    cache = _load_cache(cache_path, msal)
-
-    # Reuse cached MSAL app so acquire_token_silent can access refresh tokens.
-    # Include email in the key so different accounts don't share app state.
-    cache_key = (client_id, tenant_id, email)
-    if cache_key in _msal_app_cache:
-        app = _msal_app_cache[cache_key]
-    else:
-        print(f"Discovered Microsoft tenant: {tenant_id}")
-        app = msal.PublicClientApplication(client_id, authority=authority, token_cache=cache)
-        _msal_app_cache[cache_key] = app
+    normalized_email = email.strip().casefold()
+    application_cache_key = (client_id, authority, normalized_email)
+    msal_application = oauth2_cache.get("microsoft_application", application_cache_key)
+    if msal_application is None:
+        persistent_token_cache = oauth2_cache.create_token_cache("microsoft", client_id, tenant_id, normalized_email)
+        app_options = {"authority": authority}
+        if persistent_token_cache is not None:
+            app_options["token_cache"] = persistent_token_cache
+        msal_application = msal.PublicClientApplication(client_id, **app_options)
+        oauth2_cache.set("microsoft_application", application_cache_key, msal_application)
 
     # Try cached/refreshed token first (handles refresh tokens automatically)
-    accounts = app.get_accounts()
+    accounts = msal_application.get_accounts(username=normalized_email)
     if accounts:
-        result = app.acquire_token_silent(scopes, account=accounts[0])
+        result = msal_application.acquire_token_silent(scopes, account=accounts[0])
         if result and "access_token" in result:
-            _save_cache(cache, cache_path)  # persist any refresh-token rotation
             return result["access_token"]
 
     # Fall back to device code flow (first call or if refresh fails)
-    flow = app.initiate_device_flow(scopes=scopes)
+    flow = msal_application.initiate_device_flow(scopes=scopes)
     if "user_code" not in flow:
         print(f"Error: Could not initiate device flow: {flow.get('error_description', 'Unknown error')}")
         return None
 
     print(flow["message"])
-    result = app.acquire_token_by_device_flow(flow)
+    result = msal_application.acquire_token_by_device_flow(flow)
 
     if "access_token" in result:
-        _save_cache(cache, cache_path)  # persist newly-acquired refresh token
         return result["access_token"]
 
     print(f"Error: Could not acquire token: {result.get('error_description', 'Unknown error')}")

--- a/src/auth/oauth2_microsoft.py
+++ b/src/auth/oauth2_microsoft.py
@@ -136,14 +136,65 @@ def discover_tenant(email, account_type="auto"):
     return None
 
 
+def _msal_cache_path_for(email):
+    """
+    Per-account MSAL token cache path.
+    Contains refresh tokens — permissions restricted to owner (POSIX).
+    Environment override: OAUTH2_MICROSOFT_CACHE_DIR.
+    """
+    cache_dir = os.getenv("OAUTH2_MICROSOFT_CACHE_DIR") or os.path.expanduser("~")
+    safe = re.sub(r"[^a-zA-Z0-9]", "_", email.lower())
+    return os.path.join(cache_dir, f".msal-imap-migrate-{safe}.json")
+
+
+def _load_cache(cache_path, msal_module):
+    """Load a SerializableTokenCache from disk, if it exists."""
+    cache = msal_module.SerializableTokenCache()
+    if os.path.exists(cache_path):
+        try:
+            with open(cache_path, "r", encoding="utf-8") as f:
+                cache.deserialize(f.read())
+        except (OSError, ValueError) as e:
+            print(f"Warning: Could not load MSAL token cache from {cache_path}: {e}")
+    return cache
+
+
+def _save_cache(cache, cache_path):
+    """Persist the cache to disk if it changed, with restrictive permissions.
+
+    On POSIX, the file is created with mode 0600 atomically (via os.open with
+    the O_CREAT flag + mode arg), so refresh-token bytes never touch a
+    world-readable inode. Windows ignores the mode arg — its ACL model is
+    handled separately and defaults to inheriting the parent directory ACL,
+    which is typically the user's profile directory.
+    """
+    if not cache.has_state_changed:
+        return
+    try:
+        # os.open with O_CREAT|O_WRONLY|O_TRUNC and mode 0o600 ensures POSIX
+        # never sees a world-readable moment between file creation and chmod.
+        fd = os.open(
+            cache_path,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            0o600,
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(cache.serialize())
+    except OSError as e:
+        print(f"Warning: Could not save MSAL token cache to {cache_path}: {e}")
+
+
 def acquire_token(client_id, email, account_type="auto"):
     """
     Acquires a Microsoft OAuth2 access token using the MSAL device code flow.
     Auto-discovers tenant ID from the email domain.
     Requires the 'msal' package: pip install msal
 
-    On subsequent calls, silently refreshes the token using the cached MSAL app
-    (which holds the refresh token in its in-memory cache).
+    The token cache is persisted to disk (per email, in the user's home dir
+    by default; override with OAUTH2_MICROSOFT_CACHE_DIR). After the first
+    interactive device-code approval, subsequent process invocations reuse
+    the refresh token silently — enabling cron use. Cache files contain
+    refresh tokens (secrets) and are written with mode 0600 on POSIX.
     """
     tenant_id = discover_tenant(email, account_type)
     if not tenant_id:
@@ -164,13 +215,18 @@ def acquire_token(client_id, email, account_type="auto"):
     # resource URL, not outlook.office365.com, or AADSTS70011 fires.
     scopes = get_imap_scopes(tenant_id)
 
-    # Reuse cached MSAL app so acquire_token_silent can access refresh tokens
-    cache_key = (client_id, tenant_id)
+    # Load persistent cache — enables non-interactive cron use.
+    cache_path = _msal_cache_path_for(email)
+    cache = _load_cache(cache_path, msal)
+
+    # Reuse cached MSAL app so acquire_token_silent can access refresh tokens.
+    # Include email in the key so different accounts don't share app state.
+    cache_key = (client_id, tenant_id, email)
     if cache_key in _msal_app_cache:
         app = _msal_app_cache[cache_key]
     else:
         print(f"Discovered Microsoft tenant: {tenant_id}")
-        app = msal.PublicClientApplication(client_id, authority=authority)
+        app = msal.PublicClientApplication(client_id, authority=authority, token_cache=cache)
         _msal_app_cache[cache_key] = app
 
     # Try cached/refreshed token first (handles refresh tokens automatically)
@@ -178,6 +234,7 @@ def acquire_token(client_id, email, account_type="auto"):
     if accounts:
         result = app.acquire_token_silent(scopes, account=accounts[0])
         if result and "access_token" in result:
+            _save_cache(cache, cache_path)  # persist any refresh-token rotation
             return result["access_token"]
 
     # Fall back to device code flow (first call or if refresh fails)
@@ -190,6 +247,7 @@ def acquire_token(client_id, email, account_type="auto"):
     result = app.acquire_token_by_device_flow(flow)
 
     if "access_token" in result:
+        _save_cache(cache, cache_path)  # persist newly-acquired refresh token
         return result["access_token"]
 
     print(f"Error: Could not acquire token: {result.get('error_description', 'Unknown error')}")

--- a/test/auth/test_imap_oauth2.py
+++ b/test/auth/test_imap_oauth2.py
@@ -17,17 +17,16 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../src")))
 
 from auth import imap_oauth2, oauth2_google, oauth2_microsoft
+from auth.oauth2_cache import oauth2_cache
 
 
 @pytest.fixture(autouse=True)
 def clear_oauth2_caches():
     """Clear module-level OAuth2 caches between tests."""
-    imap_oauth2._msal_app_cache.clear()
-    imap_oauth2._google_creds_cache.clear()
+    oauth2_cache.clear_memory()
     imap_oauth2._tenant_cache.clear()
     yield
-    imap_oauth2._msal_app_cache.clear()
-    imap_oauth2._google_creds_cache.clear()
+    oauth2_cache.clear_memory()
     imap_oauth2._tenant_cache.clear()
 
 
@@ -89,7 +88,7 @@ class TestAcquireOauth2TokenForProvider:
             result = imap_oauth2.acquire_oauth2_token_for_provider("google", "cid", "user@gmail.com", "secret")
 
         assert result == "g_token"
-        mock_g.assert_called_once_with("cid", "secret")
+        mock_g.assert_called_once_with("cid", "secret", "user@gmail.com")
 
     def test_google_requires_client_secret(self, capsys):
         """Test returns None when Google is selected without client_secret."""

--- a/test/auth/test_imap_oauth2.py
+++ b/test/auth/test_imap_oauth2.py
@@ -117,6 +117,13 @@ class TestCompatibilityHelpers:
         assert result == "ms_token"
         acquire.assert_called_once_with("client-id", "user@example.com", "personal")
 
+    def test_google_token_helper_forwards_account_identity(self):
+        with patch.object(oauth2_google, "acquire_token", return_value="google-token") as acquire:
+            result = imap_oauth2.acquire_google_oauth2_token("client-id", "client-secret", email="user@gmail.com")
+
+        assert result == "google-token"
+        acquire.assert_called_once_with("client-id", "client-secret", "user@gmail.com")
+
 
 class TestRefreshOauth2Token:
     """Tests for thread-safe refresh_oauth2_token function."""

--- a/test/auth/test_oauth2_cache.py
+++ b/test/auth/test_oauth2_cache.py
@@ -1,0 +1,149 @@
+"""Tests for the provider-neutral OAuth2 cache."""
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+from msal import TokenCache
+from msal_extensions import FilePersistence, PersistedTokenCache
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../src")))
+
+from auth.oauth2_cache import MsalExtensionsOAuth2CacheProvider
+from conftest import temp_env
+
+
+class TestMemoryCache:
+    def test_objects_are_partitioned_by_namespace_and_key(self):
+        provider = MsalExtensionsOAuth2CacheProvider()
+        provider.set("google", ("client", "user"), "google-value")
+        provider.set("microsoft", ("client", "user"), "microsoft-value")
+
+        assert provider.get("google", ("client", "user")) == "google-value"
+        assert provider.get("microsoft", ("client", "user")) == "microsoft-value"
+
+        provider.clear_memory()
+        assert provider.get("google", ("client", "user")) is None
+
+
+class TestPersistentCache:
+    @pytest.mark.parametrize(
+        ("platform", "environment", "suffix"),
+        [
+            ("win32", {"LOCALAPPDATA": "/local"}, "/local/imap-migration-tools"),
+            ("linux", {"XDG_CACHE_HOME": "/cache"}, "/cache/imap-migration-tools"),
+        ],
+    )
+    def test_default_directory_uses_platform_convention(self, platform, environment, suffix):
+        provider = MsalExtensionsOAuth2CacheProvider()
+        with pytest.MonkeyPatch.context() as monkeypatch, temp_env(environment):
+            monkeypatch.setattr(sys, "platform", platform)
+            assert provider._cache_dir() == suffix
+
+    def test_default_directory_uses_macos_cache(self):
+        provider = MsalExtensionsOAuth2CacheProvider()
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(sys, "platform", "darwin")
+            assert provider._cache_dir().endswith("/Library/Caches/imap-migration-tools")
+
+    def test_paths_are_normalized_partitioned_and_non_identifying(self, tmp_path):
+        provider = MsalExtensionsOAuth2CacheProvider()
+        with temp_env({"OAUTH2_CACHE_DIR": str(tmp_path)}):
+            first = provider.cache_path("google", "Client-A", " User@Example.com ")
+            same_identity = provider.cache_path("google", "client-a", "user@example.com")
+            other_provider = provider.cache_path("microsoft", "client-a", "user@example.com")
+
+        assert first == same_identity
+        assert first != other_provider
+        assert "user@example.com" not in first
+
+    @pytest.mark.parametrize(("value", "enabled"), [("true", True), ("OFF", False)])
+    def test_enable_switch(self, value, enabled):
+        provider = MsalExtensionsOAuth2CacheProvider()
+        with temp_env({"OAUTH2_CACHE_ENABLED": value}):
+            assert provider.persistent_cache_enabled() is enabled
+
+    def test_generic_values_round_trip_through_real_persistence(self, tmp_path):
+        provider = MsalExtensionsOAuth2CacheProvider(encrypted_persistence_builder=FilePersistence)
+        cache_dir = tmp_path / "private-cache"
+        with temp_env({"OAUTH2_CACHE_DIR": str(cache_dir)}):
+            assert provider.load("google", "client", "user@example.com") is None
+            assert provider.save("google", '{"refresh_token":"synthetic"}', "client", "user@example.com")
+            assert provider.load("google", "client", "user@example.com") == '{"refresh_token":"synthetic"}'
+
+        assert cache_dir.stat().st_mode & 0o077 == 0
+
+    def test_msal_token_cache_round_trips_through_real_persistence(self, tmp_path):
+        provider = MsalExtensionsOAuth2CacheProvider(encrypted_persistence_builder=FilePersistence)
+        with temp_env({"OAUTH2_CACHE_DIR": str(tmp_path)}):
+            first_cache = provider.create_token_cache("microsoft", "client", "tenant", "user@example.com")
+            entry = {
+                "home_account_id": "account-id",
+                "environment": "login.microsoftonline.com",
+                "client_id": "client-id",
+                "secret": "synthetic-token",
+                "target": "imap-scope",
+                "realm": "tenant-id",
+                "token_type": "Bearer",
+                "expires_on": "9999999999",
+            }
+            first_cache.modify(TokenCache.CredentialType.ACCESS_TOKEN, entry, entry)
+            cache_path = provider.cache_path("microsoft", "client", "tenant", "user@example.com")
+
+        second_cache = PersistedTokenCache(FilePersistence(cache_path))
+        assert list(second_cache.search(TokenCache.CredentialType.ACCESS_TOKEN)) == [entry]
+
+    def test_encryption_failure_disables_persistence(self, tmp_path, capsys):
+        def unavailable(_path):
+            raise RuntimeError("credential store unavailable")
+
+        provider = MsalExtensionsOAuth2CacheProvider(encrypted_persistence_builder=unavailable)
+        with temp_env({"OAUTH2_CACHE_DIR": str(tmp_path)}):
+            assert provider.load("google", "client", "user") is None
+            assert provider.save("google", "value", "client", "user") is False
+            assert provider.create_token_cache("microsoft", "client", "tenant", "user") is None
+
+        output = capsys.readouterr().out
+        assert "Continuing without persistent token caching" in output
+        assert not list(tmp_path.glob("*.cache"))
+
+    def test_unavailable_directory_disables_persistence(self, tmp_path, capsys):
+        parent_file = tmp_path / "not-a-directory"
+        parent_file.write_text("occupied", encoding="utf-8")
+        provider = MsalExtensionsOAuth2CacheProvider(encrypted_persistence_builder=FilePersistence)
+
+        with temp_env({"OAUTH2_CACHE_DIR": str(parent_file)}):
+            assert provider.load("google", "client", "user") is None
+
+        assert "Persistent token caching is disabled" in capsys.readouterr().out
+
+    def test_missing_cache_library_disables_only_persistence(self, tmp_path, capsys):
+        provider = MsalExtensionsOAuth2CacheProvider()
+        with temp_env({"OAUTH2_CACHE_DIR": str(tmp_path)}), patch.dict("sys.modules", {"msal_extensions": None}):
+            assert provider.load("google", "client", "user") is None
+
+        assert "pip install msal-extensions" in capsys.readouterr().out
+
+    def test_storage_errors_do_not_escape_provider(self, tmp_path, capsys):
+        class FailingPersistence:
+            def __init__(self, location):
+                self.location = location
+
+            def get_location(self):
+                return self.location
+
+            def load(self):
+                raise RuntimeError("load failed")
+
+            def save(self, _value):
+                raise RuntimeError("save failed")
+
+        provider = MsalExtensionsOAuth2CacheProvider(encrypted_persistence_builder=FailingPersistence)
+        with temp_env({"OAUTH2_CACHE_DIR": str(tmp_path)}):
+            assert provider.load("google", "client", "user") is None
+            assert provider.save("google", "value", "client", "user") is False
+
+        output = capsys.readouterr().out
+        assert "Could not load the google persistent token cache" in output
+        assert "Could not save the google persistent token cache" in output

--- a/test/auth/test_oauth2_google.py
+++ b/test/auth/test_oauth2_google.py
@@ -6,6 +6,7 @@ Tests cover:
 - Credentials caching and silent token refresh
 """
 
+import json
 import os
 import sys
 from unittest.mock import MagicMock, patch
@@ -15,14 +16,16 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../src")))
 
 from auth import oauth2_google
+from auth.oauth2_cache import oauth2_cache
 
 
 @pytest.fixture(autouse=True)
-def clear_caches():
+def clear_caches(monkeypatch):
     """Clear module-level caches between tests."""
-    oauth2_google._creds_cache.clear()
+    monkeypatch.setenv("OAUTH2_CACHE_ENABLED", "false")
+    oauth2_cache.clear_memory()
     yield
-    oauth2_google._creds_cache.clear()
+    oauth2_cache.clear_memory()
 
 
 class TestAcquireToken:
@@ -89,7 +92,7 @@ class TestAcquireToken:
         with patch.dict("sys.modules", {"google_auth_oauthlib": MagicMock(), "google_auth_oauthlib.flow": mock_module}):
             oauth2_google.acquire_token("client-id", "client-secret")
 
-        assert ("client-id", "client-secret") in oauth2_google._creds_cache
+        assert oauth2_cache.get("google_credentials", ("client-id", "default")) is mock_credentials
 
     def test_cached_credentials_refreshed_on_second_call(self):
         """Test second call refreshes cached credentials without opening browser."""
@@ -97,23 +100,56 @@ class TestAcquireToken:
         mock_creds = MagicMock()
         mock_creds.refresh_token = "refresh_tok"
         mock_creds.token = "refreshed_google_token"
-        oauth2_google._creds_cache[("client-id", "client-secret")] = mock_creds
+        oauth2_cache.set("google_credentials", ("client-id", "default"), mock_creds)
 
-        mock_request_module = MagicMock()
-        with patch.dict(
-            "sys.modules",
-            {
-                "google": MagicMock(),
-                "google.auth": MagicMock(),
-                "google.auth.transport": MagicMock(),
-                "google.auth.transport.requests": mock_request_module,
-            },
-        ):
+        with patch("google.auth.transport.requests.Request"):
             result = oauth2_google.acquire_token("client-id", "client-secret")
 
         assert result == "refreshed_google_token"
         # Verify refresh was called
         mock_creds.refresh.assert_called_once()
+
+    def test_persistent_credentials_are_restored_and_refreshed(self):
+        mock_creds = MagicMock()
+        mock_creds.refresh_token = "refresh-token"
+        mock_creds.token = "refreshed-token"
+        mock_creds.to_json.return_value = '{"updated":true}'
+        serialized = json.dumps(
+            {
+                "client_id": "client-id",
+                "client_secret": "client-secret",
+                "refresh_token": "refresh-token",
+                "token_uri": "https://oauth2.googleapis.com/token",
+            }
+        )
+
+        with (
+            patch.object(oauth2_google.oauth2_cache, "load", return_value=serialized),
+            patch.object(oauth2_google.oauth2_cache, "save", return_value=True) as save,
+            patch("google.oauth2.credentials.Credentials.from_authorized_user_info", return_value=mock_creds),
+            patch("google.auth.transport.requests.Request"),
+        ):
+            result = oauth2_google.acquire_token("client-id", "client-secret", "User@Gmail.com")
+
+        assert result == "refreshed-token"
+        assert oauth2_google.oauth2_cache.get("google_credentials", ("client-id", "user@gmail.com")) is mock_creds
+        save.assert_called_once_with("google", '{"updated":true}', "client-id", "user@gmail.com")
+
+    def test_invalid_persistent_credentials_fall_back_to_browser(self, capsys):
+        mock_credentials = MagicMock()
+        mock_credentials.token = "browser-token"
+        mock_flow = MagicMock()
+        mock_flow.run_local_server.return_value = mock_credentials
+
+        with (
+            patch.object(oauth2_google.oauth2_cache, "load", return_value="not-json"),
+            patch.object(oauth2_google.oauth2_cache, "save", return_value=True),
+            patch("google_auth_oauthlib.flow.InstalledAppFlow.from_client_config", return_value=mock_flow),
+        ):
+            result = oauth2_google.acquire_token("client-id", "client-secret", "user@gmail.com")
+
+        assert result == "browser-token"
+        assert "Could not restore cached Google credentials" in capsys.readouterr().out
 
     def test_falls_back_to_browser_if_refresh_fails(self):
         """Test falls back to full auth flow if cached token refresh fails."""
@@ -121,7 +157,7 @@ class TestAcquireToken:
         mock_creds = MagicMock()
         mock_creds.refresh_token = "refresh_tok"
         mock_creds.refresh.side_effect = Exception("Refresh failed")
-        oauth2_google._creds_cache[("client-id", "client-secret")] = mock_creds
+        oauth2_cache.set("google_credentials", ("client-id", "default"), mock_creds)
 
         # Set up the full auth flow
         mock_credentials = MagicMock()
@@ -146,7 +182,7 @@ class TestAcquireToken:
         # Pre-populate cache with credentials that have no refresh token
         mock_creds = MagicMock()
         mock_creds.refresh_token = None
-        oauth2_google._creds_cache[("client-id", "client-secret")] = mock_creds
+        oauth2_cache.set("google_credentials", ("client-id", "default"), mock_creds)
 
         # Set up the full auth flow
         mock_credentials = MagicMock()

--- a/test/auth/test_oauth2_microsoft.py
+++ b/test/auth/test_oauth2_microsoft.py
@@ -17,6 +17,7 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../src")))
 
 from auth import oauth2_microsoft
+from auth.oauth2_cache import oauth2_cache
 from conftest import temp_env
 from mock_oauth_server import MOCK_TENANT_ID
 
@@ -38,10 +39,10 @@ EXPECTED_PERSONAL_MICROSOFT_DOMAINS = {
 @pytest.fixture(autouse=True)
 def clear_caches():
     """Clear module-level caches between tests."""
-    oauth2_microsoft._msal_app_cache.clear()
+    oauth2_cache.clear_memory()
     oauth2_microsoft._tenant_cache.clear()
     yield
-    oauth2_microsoft._msal_app_cache.clear()
+    oauth2_cache.clear_memory()
     oauth2_microsoft._tenant_cache.clear()
 
 
@@ -182,6 +183,12 @@ class TestImapScopes:
 class TestAcquireToken:
     """Tests for acquire_token function."""
 
+    @pytest.fixture(autouse=True)
+    def disable_persistent_cache(self):
+        """Keep mocked acquisition tests isolated from the user's credential store."""
+        with temp_env({"OAUTH2_CACHE_ENABLED": "false"}):
+            yield
+
     def test_successful_token(self):
         """Test successful token acquisition with auto-discovery."""
         with patch.object(oauth2_microsoft, "discover_tenant", return_value="tenant-123"):
@@ -212,7 +219,12 @@ class TestAcquireToken:
             mock_msal.PublicClientApplication.return_value = mock_app
 
             with patch.dict("sys.modules", {"msal": mock_msal}):
-                with temp_env({"OAUTH2_MICROSOFT_AUTHORITY_BASE_URL": custom_base}):
+                with temp_env(
+                    {
+                        "OAUTH2_MICROSOFT_AUTHORITY_BASE_URL": custom_base,
+                        "OAUTH2_CACHE_ENABLED": "false",
+                    }
+                ):
                     oauth2_microsoft.acquire_token("client-id", "user@test.com")
 
             mock_msal.PublicClientApplication.assert_called_with("client-id", authority=expected_authority)
@@ -238,9 +250,43 @@ class TestAcquireToken:
                 result = oauth2_microsoft.acquire_token("client-id", "user@test.com")
 
             assert result == "cached_token"
+            mock_app.get_accounts.assert_called_once_with(username="user@test.com")
 
-    def test_msal_app_cached_on_first_call(self):
-        """Test MSAL app is cached after first call."""
+    def test_persistent_token_cache_is_attached_to_new_application(self, tmp_path):
+        with patch.object(oauth2_microsoft, "discover_tenant", return_value="tenant-123"):
+            mock_msal = MagicMock()
+            mock_app = MagicMock()
+            mock_app.get_accounts.return_value = []
+            mock_app.initiate_device_flow.return_value = {"user_code": "ABC", "message": "Go to..."}
+            mock_app.acquire_token_by_device_flow.return_value = {"access_token": "token"}
+            mock_msal.PublicClientApplication.return_value = mock_app
+            persistent_token_cache = object()
+
+            with (
+                patch.dict("sys.modules", {"msal": mock_msal}),
+                patch.object(
+                    oauth2_cache,
+                    "create_token_cache",
+                    return_value=persistent_token_cache,
+                ) as create_token_cache,
+            ):
+                with temp_env(
+                    {
+                        "OAUTH2_CACHE_ENABLED": "true",
+                        "OAUTH2_CACHE_DIR": str(tmp_path),
+                    }
+                ):
+                    oauth2_microsoft.acquire_token("client-id", "User@Test.com")
+
+            create_token_cache.assert_called_once_with("microsoft", "client-id", "tenant-123", "user@test.com")
+            mock_msal.PublicClientApplication.assert_called_once_with(
+                "client-id",
+                authority="https://login.microsoftonline.com/tenant-123",
+                token_cache=persistent_token_cache,
+            )
+
+    def test_msal_application_cached_on_first_call(self):
+        """Test the MSAL application is cached after the first call."""
         with patch.object(oauth2_microsoft, "discover_tenant", return_value="tenant-123"):
             mock_msal = MagicMock()
             mock_app = MagicMock()
@@ -252,10 +298,12 @@ class TestAcquireToken:
             with patch.dict("sys.modules", {"msal": mock_msal}):
                 oauth2_microsoft.acquire_token("client-id", "user@test.com")
 
-            assert ("client-id", "tenant-123") in oauth2_microsoft._msal_app_cache
+            expected_authority = "https://login.microsoftonline.com/tenant-123"
+            application_cache_key = ("client-id", expected_authority, "user@test.com")
+            assert oauth2_cache.get("microsoft_application", application_cache_key) is mock_app
 
-    def test_cached_app_reused_on_second_call(self):
-        """Test second call reuses cached MSAL app instead of creating new one."""
+    def test_cached_application_reused_on_second_call(self):
+        """Test the second call reuses the cached MSAL application."""
         with patch.object(oauth2_microsoft, "discover_tenant", return_value="tenant-123"):
             mock_msal = MagicMock()
             mock_app = MagicMock()
@@ -299,6 +347,20 @@ class TestAcquireToken:
                 result = oauth2_microsoft.acquire_token("client-id", "user@test.com")
 
             assert result is None
+
+    def test_device_flow_initialization_failure(self, capsys):
+        with patch.object(oauth2_microsoft, "discover_tenant", return_value="tenant-123"):
+            mock_msal = MagicMock()
+            mock_app = MagicMock()
+            mock_app.get_accounts.return_value = []
+            mock_app.initiate_device_flow.return_value = {"error_description": "device flow unavailable"}
+            mock_msal.PublicClientApplication.return_value = mock_app
+
+            with patch.dict("sys.modules", {"msal": mock_msal}):
+                result = oauth2_microsoft.acquire_token("client-id", "user@test.com")
+
+        assert result is None
+        assert "device flow unavailable" in capsys.readouterr().out
 
 
 class TestFetchJsonHttps:


### PR DESCRIPTION
## Summary

Introduce a provider-neutral OAuth2 cache abstraction backed by MSAL Extensions and use it for both Microsoft and Google authentication.

## Original problem

The original Microsoft cache implementation built persistence from scratch around `SerializableTokenCache`. That approach required the project to own security-sensitive details such as file permissions, serialization, concurrent access, reload behavior, and writes. It also contained correctness risks around reused MSAL application objects being attached to stale cache instances, selecting the first cached account instead of the requested username, cache filename collisions, and non-atomic or concurrent writes.

Caching was also embedded directly in the Microsoft authentication module, which meant another OAuth provider would need to duplicate the same path, encryption, locking, configuration, and failure-handling behavior.

## Solution

- Add a shared OAuth2 cache provider in `auth/oauth2_cache.py`.
- Implement the provider with `msal-extensions` rather than custom persistence code.
- Centralize process-local caching, cache path generation, encrypted persistence creation, cross-process locking, configuration, and failure handling.
- Keep cache identities isolated by provider, client, tenant where applicable, and normalized account.
- Use collision-resistant hashed filenames that do not expose account addresses.
- Configure the shared provider through `OAUTH2_CACHE_ENABLED` and `OAUTH2_CACHE_DIR`.

### Microsoft OAuth2

Microsoft authentication asks the shared provider for an MSAL-compatible `PersistedTokenCache` and stores process-local `PublicClientApplication` objects through the same provider. MSAL Extensions supplies automatic reload and coordinated persistence. Cached account lookup is filtered by normalized username.

### Google OAuth2

Google authentication serializes and restores `google.oauth2.credentials.Credentials` through the shared provider. Persisted refresh credentials can therefore refresh access tokens without reopening the browser on every process invocation. Updated credentials are saved after refresh and after the installed-app authorization flow.

The OAuth modules no longer implement cache directories, encryption, locking, or persistence themselves. Replacing the cache backend later only requires changing the shared provider.

## Security

- Tokens are persisted only through platform-encrypted storage provided by MSAL Extensions: Keychain on macOS, DPAPI on Windows, and LibSecret on supported Linux systems.
- There is no plaintext persistence fallback.
- If encrypted storage or `msal-extensions` is unavailable, authentication continues with process-local caching only.
- Generic persistent operations use cross-process locks.
- Cache directories created by the provider use owner-only permissions on POSIX systems.

## Documentation and contributor guidance

- Document shared Microsoft and Google persistent caching and the generic cache environment variables.
- Add a complete Microsoft migration example with cache configuration.
- Add contributor guidance requiring investigation of maintained libraries before implementing new features from scratch, with an explicit preference for libraries in authentication, encryption, caching, and database work.

## Verification

- Full test suite: `481 passed`
- Shared cache provider coverage: `100%`
- Google OAuth2 coverage: `100%`
- Ruff lint: passed
- Ruff format check: passed
- `git diff --check`: passed